### PR TITLE
Script to build and deploy to s3

### DIFF
--- a/ops/deploy_s3.sh
+++ b/ops/deploy_s3.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+##
+# Run this script from the root of the project:
+#
+#   ./ops/deploy_s3.sh <site-dir> <s3-bucket>
+##
+
+set -e
+
+SITE_DIR=${1:-"_site"}
+S3_BUCKET=${2:-"bluebutton.cms.gov"}
+
+gem install  --no-ri --no-rdoc bundler
+bundle install
+bundle exec jekyll build
+aws s3 sync --delete ./$SITE_DIR/ s3://$S3_BUCKET


### PR DESCRIPTION
Updated version of the script initially proposed in #1. This version of the script builds _and_ deploys the site.

Usage: `./ops/deploy.sh <local-build-dir> <s3-bucket>`

The `<local-build-dir>` and `<s3-bucket>` args are optional.