### PR TITLE
CBBI-314: First cut of Jekyll generator for API codesets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,5 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+# Pre-requisites for the `_plugins/api_codings.rb` plugin:
+gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
+    mini_portile2 (2.3.0)
     minima (2.1.1)
       jekyll (~> 3.3)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     pathutil (0.16.0)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.0)
@@ -52,7 +55,8 @@ DEPENDENCIES
   jekyll (= 3.5.2)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
+  nokogiri
   tzinfo-data
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/_codebooks/codebook-ffs-claims-trimmed.xml
+++ b/_codebooks/codebook-ffs-claims-trimmed.xml
@@ -1,0 +1,39 @@
+<codes>
+    <code>
+      <name>ACO_ID_NUM</name>
+      <label>Claim Accountable Care Organization (ACO) Identification Number</label>
+      <description><p>The field identifies the Accountable Care Organization (ACO) Identification Number.</p></description>
+      <shortName>ACO_ID_NUM</shortName>
+      <longName>ACO_ID_NUM</longName>
+      <type>CHAR</type>
+      <length>10</length>
+      <source>NCH</source>
+      <valueFormat></valueFormat>
+      <values>
+        <valuegroup>
+          <description>-</description>
+        </valuegroup>
+      </values>
+      <comment><p>-</p></comment>
+    </code>
+    <code>
+      <name>ACTIONCD</name>
+      <label>FI or MAC Claim Action Code</label>
+      <description><p>The type of action requested by the intermediary to be taken on an institutional claim.</p></description>
+      <shortName>ACTIONCD</shortName>
+      <longName>FI_CLM_ACTN_CD</longName>
+      <type>CHAR</type>
+      <length>1</length>
+      <source>NCH</source>
+      <valueFormat></valueFormat>
+      <values>
+        <valuegroup>
+          <description></description>
+          <value value="1" description="Original debit action (always a 1 for all regular bills)"/>
+          <value value="5" description="Force action code 3 (secondary debit adjustment)"/>
+          <value value="8" description="Benefits refused"/>
+        </valuegroup>
+      </values>
+      <comment><p>-</p></comment>
+    </code>
+</codes>

--- a/_config.yml
+++ b/_config.yml
@@ -42,3 +42,10 @@ exclude:
   - package.json
   - Jenkinsfile
   - ops
+
+# Configure the `_plugins/api_codings.rb` plugin. Note that you can run
+# `bundle exec jekyll serve --verbose` to get debug output from that plugin.
+codebooks:
+  layout: codeset.html
+  xml_files:
+    - _codebooks/codebook-ffs-claims-trimmed.xml

--- a/_layouts/codeset.html
+++ b/_layouts/codeset.html
@@ -1,0 +1,42 @@
+---
+layout: default
+---
+<h1>Codeset: {{ page.id | upcase }}</h1>
+<p>{{ page.label }}</p>
+
+<h2>Description</h2>
+{% for paragraph in page.description %}
+<p>{{ paragraph }}</p>  
+{% endfor %}
+
+{% if page.value_groups.size > 0 %}
+<h2>Values</h2>
+This field is a codeset, and will always contain one of the following values.
+
+{% for value_group in page.value_groups %}
+
+{% if value_group['description'] != '' %}
+<h3>{{ value_group['description'] }}</h3>
+{% endif %}
+
+<table class="ds-c-table">
+  <caption>Values for Codeset</caption>
+  <thead>
+    <tr>
+      <th scope="col">Value</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for value_entry in value_group['values'] %}
+    <tr>
+      <th scope="row"><code>{{ value_entry['value'] }}</code></th>
+      <td>{{ value_entry['description'] }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+{% endfor %}
+
+{% endif %}

--- a/_plugins/api_codings.rb
+++ b/_plugins/api_codings.rb
@@ -1,0 +1,141 @@
+# This plugin library provides a CodingGenerator plugin for Jekyll, which can
+# produce additional pages in the site's rendered output. See the documentation
+# on the class below for more details.
+
+require 'nokogiri'
+
+module BlueButtonApi
+  # Each Codeset instance represents a second-level `<code/>` element parsed
+  # from one the codebook PDFs.
+  #
+  # This class just acts as a convenience utility to prevent CodingPage from
+  # having to handle Nokogiri/XML directly.
+  class Codeset
+    attr_reader :id
+
+    def initialize(codeset_xml)
+      @codeset_xml = codeset_xml
+
+      # Pull out an `id` attribute that uniquely identifies this codeset within
+      # its codebook.
+      data_tmp = {}
+      generate_data(data_tmp)
+      @id = data_tmp['id']
+    end
+
+    def generate_data(data)
+      # Can't use just `name` here, as Jekyll replaces that field.
+      data['id'] = @codeset_xml.xpath('.//name')[0].content.downcase
+
+      data['label'] = @codeset_xml.xpath('.//label')[0].content
+      data['description'] = parse_paragraphs(@codeset_xml.xpath('.//description')[0])
+      data['short_name'] = @codeset_xml.xpath('.//shortName')[0].content
+      data['long_name'] = @codeset_xml.xpath('.//longName')[0].content
+      data['type'] = @codeset_xml.xpath('.//type')[0].content
+      data['length'] = @codeset_xml.xpath('.//length')[0].content
+      data['source'] = @codeset_xml.xpath('.//source')[0].content
+      data['value_format'] = @codeset_xml.xpath('.//valueFormat')[0].content
+      data['value_groups'] = parse_value_groups(@codeset_xml.xpath('.//values')[0])
+      data['comment'] = parse_paragraphs(@codeset_xml.xpath('.//comment')[0])
+    end
+
+    def parse_paragraphs(paragraphs_xml)
+      paragraphs = []
+      paragraphs_xml.xpath('.//p').each do |paragraph|
+        paragraphs.push(paragraph.content)
+      end
+      return paragraphs
+    end
+
+    def parse_value_groups(value_groups_xml)
+      value_groups = []
+
+      # Each <values/> can have multiple <valuegroups/>.
+      value_groups_xml.xpath('.//valuegroup').each do |value_group_xml|
+        value_group = {}
+	
+        # Each <valuegroup/> can have a single <description/>.
+        value_group['description'] = value_group_xml.content.strip
+
+        # Each <valuegroup/> can have multiple <values/>.
+	value_group['values'] = []
+        value_group_xml.xpath('.//value').each do |value_xml|
+          value = {}
+
+          value['value'] = value_xml['value'].strip
+          value['description'] = value_xml['description'].strip
+
+          value_group['values'].push(value)
+        end
+
+        value_groups.push(value_group)
+      end
+
+      return value_groups
+    end
+  end
+end
+
+module Jekyll
+  # Each CodingPage instance represents a Jekyll page that can be rendered,
+  # providing documentation for the BlueButtonApi::Codeset that it represents.
+  class CodingPage < Page
+    def initialize(site, codeset)
+      @site = site
+      @base = site.source
+      @dir = codeset.id
+      @name = 'index.html'
+
+      self.process(@name)
+
+      # Despite the name, the most important thing that this method does is to
+      # set the specified file as the layout to use for this page.
+      self.read_yaml(File.join(@base, '_layouts'), site.config['codebooks']['layout'])
+
+      # Values in the page's `data` hash can be used by the layout for
+      # rendering.
+      codeset.generate_data(self.data)
+    end
+  end
+
+  # CodingGenerator is a Jekyll Generator plugin, which can produce pages that
+  # will be included in the site's rendered output.
+  #
+  # It relies on config like the following in the site's `_config.yml`:
+  #
+  # codebooks:
+  #   layout: codeset.html
+  #   xml_files:
+  #     - _codebooks/some-codebook-file.xml
+  #
+  # In the above config, the `layout` is the name of the file in the site's
+  # `_layouts` directory, which will be used to render each `CodingPage`
+  # instance produced by this Generator. The `xml_files` are the XML files that
+  # pages will be generated from/for.
+  class CodingGenerator < Generator
+    safe true
+
+    def generate(site)
+      # Verify that the required configuration for this plugin is present.
+      Jekyll.logger.debug('CodingGenerator:', 'Verifying configuration...')
+      return unless site.config.key? 'codebooks'
+      return unless site.config['codebooks'].key? 'layout'
+      return unless site.config['codebooks'].key? 'xml_files'
+      Jekyll.logger.debug('CodingGenerator:', 'Configured.')
+
+      # Parse each XML file and generate a `CodingPage` for each `<code/>`
+      # entry.
+      site.config['codebooks']['xml_files'].each do |xml_file|
+        Jekyll.logger.info('CodingGenerator:', "Processing codebook XML file '#{xml_file}'...")
+        codebook_doc = Nokogiri::XML(File.open(xml_file))
+        Jekyll.logger.debug('CodingGenerator:', codebook_doc)
+        codebook_doc.xpath('/codes//code').each do |codeset_xml|
+          codeset = BlueButtonApi::Codeset.new(codeset_xml)
+          Jekyll.logger.debug('CodingGenerator:', "Found codeset: '#{codeset.id}'")
+	  site.pages << CodingPage.new(site, codeset)
+        end
+        Jekyll.logger.info('CodingGenerator:', "Processed codebook XML file '#{xml_file}'.")
+      end
+    end
+  end
+end

--- a/_plugins/api_codings.rb
+++ b/_plugins/api_codings.rb
@@ -83,7 +83,7 @@ module Jekyll
     def initialize(site, codeset)
       @site = site
       @base = site.source
-      @dir = codeset.id
+      @dir = File.join('resources', codeset.id)
       @name = 'index.html'
 
       self.process(@name)


### PR DESCRIPTION
The magic happens in the api_codings.rb plugin file being added. It
takes in the codebook XML files produced by
<https://github.com/CMSgov/bluebutton-data-model/tree/master/bluebutton-data-model-codebook-extractor>
and uses them to produce Jekyll output pages.

Definitely not 100% done, but a solid first pass. Known issues:

* The real codebook XML files are missing, as the code used to produce
  them has some not-yet-fixed bugs. Added a bespoke, artisal, locally
  produced (and Hipster-friendly) sample in the meantime.
  Even this sample still has some problems, such as the not-quite-empty
  value entries.
* The layout/design of the rendered pages is bad. Very.

https://issues.hhsdevcloud.us/browse/CBBI-314