### PR TITLE
Updates to make sure the site is served over https only

### DIFF
--- a/ops/terraform/bluebutton.cms.gov/templates/nginx.conf
+++ b/ops/terraform/bluebutton.cms.gov/templates/nginx.conf
@@ -9,17 +9,26 @@ events {
 
 http {
   server {
+    listen 81;
+    server_name _;
+
+    location /_health {
+      return 200 'OK';
+    }
+  }
+
+  server {
     listen 80;
     server_name _;
     server_tokens off;
 
     # redirect original non-HTTPS req to HTTPS
-    #if ($http_x_forwarded_proto != "https") {
-    #  rewrite ^(.*)$ https://$http_host$1 permanent;
-    #}
+    if ($http_x_forwarded_proto != "https") {
+      rewrite ^(.*)$ https://$http_host$1 permanent;
+    }
 
     # enforce HSTS policy (force clients to use HTTPS)
-    #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
 
     # This RESOLVER marker is replaced by user_data script
     resolver |RESOLVER| valid=300s;

--- a/ops/terraform/bluebutton.cms.gov/variables.tf
+++ b/ops/terraform/bluebutton.cms.gov/variables.tf
@@ -23,3 +23,9 @@ variable "nat_gw_cdir" { }
 variable "config_bucket" { }
 
 variable "bucket_name" { }
+
+variable "asg_min" { }
+
+variable "asg_max" { }
+
+variable "asg_desired" { }


### PR DESCRIPTION
- Redirect http to https requests
- Enforce https by setting `Strict-Transport-Security` header
- Configure the ALB with TLS certificate
- Update to ALB health check endpoint