### PR TITLE
Fix for intermittent 'bad gateway' from nginx, other misc. changes

### DIFF
--- a/ops/terraform/bluebutton.cms.gov/main.tf
+++ b/ops/terraform/bluebutton.cms.gov/main.tf
@@ -166,7 +166,7 @@ resource "aws_s3_bucket" "main" {
 
   website {
     index_document = "index.html"
-    error_document = "index.html"
+    error_document = "404.html"
   }
 
   tags {

--- a/ops/terraform/bluebutton.cms.gov/templates/bucket-policy.json
+++ b/ops/terraform/bluebutton.cms.gov/templates/bucket-policy.json
@@ -16,6 +16,22 @@
           "aws:SourceIp": "${nat_gw_cdir}"
         }
       }
+    },
+    {
+      "Sid": "Stmt1516660482311",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}"
+      ],
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": "${nat_gw_cdir}"
+        }
+      }
     }
   ]
 }

--- a/ops/terraform/bluebutton.cms.gov/templates/nginx.conf
+++ b/ops/terraform/bluebutton.cms.gov/templates/nginx.conf
@@ -30,8 +30,7 @@ http {
     # enforce HSTS policy (force clients to use HTTPS)
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
 
-    # This RESOLVER marker is replaced by user_data script
-    resolver |RESOLVER| valid=300s;
+    resolver 169.254.169.253 valid=30s;
     resolver_timeout 5s;
 
     merge_slashes off;

--- a/ops/terraform/bluebutton.cms.gov/templates/user_data
+++ b/ops/terraform/bluebutton.cms.gov/templates/user_data
@@ -9,9 +9,5 @@ cat > /etc/nginx/nginx.conf << EOM
 ${nginx_conf}
 EOM
 
-# Replace |RESOLVER| marker in nginx.conf
-RESOLVER=$(cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}')
-sed -i "s/|RESOLVER|/$(echo $RESOLVER | sed 's/\./\\./g')/g" /etc/nginx/nginx.conf
-
 # Restart the service
 service nginx restart;

--- a/ops/terraform/test.bluebutton.cms.gov/main.tf
+++ b/ops/terraform/test.bluebutton.cms.gov/main.tf
@@ -23,7 +23,7 @@ resource "aws_s3_bucket" "main" {
 
   website {
     index_document = "index.html"
-    error_document = "index.html"
+    error_document = "404.html"
   }
 
   tags {


### PR DESCRIPTION
Changes nginx's `resolver` directive to use Amazon DNS server. This should fix intermittent 'bad gateway' errors caused by DNS resolution timeouts.

Otherwise, I've included a few changes to fix error docs for the prod and test sites and change the behavior of the prod site to return a 404 instead of 403 when requested document is not found.