### PR TITLE
Fix rewrite rule for sub pages

### DIFF
--- a/ops/terraform/bluebutton.cms.gov/templates/nginx.conf
+++ b/ops/terraform/bluebutton.cms.gov/templates/nginx.conf
@@ -71,7 +71,7 @@ http {
       rewrite ^$ /$bucket_name/index.html break;
 
       # Rewrite URLs that don't contain '.' and end in '/' to '/index.html'
-      rewrite ^([^.])/$ /$bucket_name/$1/index.html break;
+      rewrite ^([^.]*)/$ /$bucket_name$1/index.html break;
 
       # Rewrite everything to /$bucket_name
       rewrite ^(.*)$ /$bucket_name$1 break;


### PR DESCRIPTION
This rule was not working properly because it was not configured match more than a single character in a path. This fix will ensure the nginx proxy fetches the correct `index.html` file for a given sub-page/path of the site. For example: `/developers/` will now properly proxy to the`/developers/index.html` object in the S3 bucket.