### PR TITLE
CBBI-343: Codebook URLs now '/resources/variables/xxx'.

### DIFF
--- a/_plugins/api_codings.rb
+++ b/_plugins/api_codings.rb
@@ -100,7 +100,7 @@ module Jekyll
     def initialize(site, variable)
       @site = site
       @base = site.source
-      @dir = File.join('resources', variable.id)
+      @dir = File.join('resources', 'variables', variable.id)
       @name = 'index.html'
 
       self.process(@name)


### PR DESCRIPTION
This allows us to (eventually) host other stuff under '/resources/' without having to worry about collisions.

https://issues.hhsdevcloud.us/browse/CBBI-343