### PR TITLE
Terms and Developer Guidelines

### DIFF
--- a/_layouts/terms.html
+++ b/_layouts/terms.html
@@ -1,0 +1,61 @@
+---
+layout: default
+---
+<div class="ds-base">
+  <header class="main-header ds-u-margin-bottom--2 ds-u-lg-margin-bottom--5">
+    <div class="solid-container ds-u-padding-y--2 ds-u-lg-padding-y--5">
+      <div class="ds-l-container">
+        <div class="ds-l-row">
+          <div class="ds-u-color--white ds-l-sm-cold--12 ds-l-xl-col--10 ds-u-margin-left--auto ds-u-padding-x--4">
+
+              {% if page.badge %}
+              <span class="ds-c-badge ds-u-text-transform--uppercase">{{ page.badge | escape }}</span>
+              {% endif %}
+
+
+              <h1 class="ds-display">{{ page.title | escape }}</h1>
+              <p class="ds-text--lead">
+                {{ page.description | escape }}
+              </p>
+
+              <div class="ctas">
+              {% for item in page.ctas limit:2 %}
+              <a class="ds-c-button button--white" href="{{ item.link }}" aria-label="{{ item.title }}" target="_self">{{ item.title }} &rarr;</a>
+              {% endfor %}
+              </div>
+
+              </div>
+            </div>
+          </div>
+        </div>
+      <div class="gradient-container ds-u-padding-y--2 ds-u-lg-padding-y--5 ds-u-display--none ds-u-md-display--block">
+        </div>
+    </div>
+  </header>
+
+<section class="ds-l-container ds-base">
+  <div class="ds-l-row">
+
+    <aside class="ds-l-col--4 ds-u-margin-left--right ds-u-display--none ds-u-sm-display--block" role="complementary">
+      <nav class="subnav">
+        <h5 class="sr-only" id="page-sub-nav">Page navigation links</h5>
+        <ul class="ds-c-list ds-c-list--bare" id="mainNav" aria-labelledby="page-sub-nav">
+          {% for item in page.sections %}
+            <li><a href="#{{ item | slugify }}" aria-label="{{ item }} section, current page" class="ds-u-display--block {{ page.subnav-link-gradient }}" aria-label="{{ item }} section, current page">{{ item }}</a></li>
+          {% endfor %}
+        </ul>
+        <h5 class="sr-only" id="page-cta-nav">External navigation links</h5>
+        <ul class="ds-c-list ds-c-list--bare ds-u-margin-top--2" aria-labelledby="page-cta-nav">
+        </ul>
+      </nav>
+    </aside>
+
+
+    <article class="ds-l-col--12 ds-l-sm-col--7 {{ page.badge | slugify }}" id="main" role="main">
+      {{ content }}
+      <a href="#site-top" class="ds-c-button ds-u-margin-top--4">Back to top</a>
+    </article>
+
+
+  </div>
+</section>

--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -14,8 +14,9 @@ sections:
   - Core Resources
   - FHIR Data Model
   - Try the API
-  - Production API Access
   - Meet "Jack"
+  - Production API Access
+  - Developer Guidelines
 ctas:
   -
     title: Blue Button Home
@@ -717,6 +718,32 @@ Next, the following criteria needs to be met and verified by the CMS Blue Button
 **What happens after I am approved?**
 
 You will receive an email from the CMS Blue Button API team notifying you of approval.  You will then receive a new Client ID and Secret for your app in production.  You will use the base URL api.cms.bluebutton.gov instead of sandbox.bluebutton.cms.gov.
+
+---
+
+## Developer Guidelines
+
+Below are guidelines you should follow to be successful in your Blue Button API integration.
+
+**Your Privacy Policy**
+
+You will be asked to provide a URL to your privacy policy and terms and conditions when registering your app in the Blue Button Developer Portal.  These links should be easy to access and understand by a beneficiary using your app.  Consider using the [Model Privacy Notice](https://www.healthit.gov/policy-researchers-implementers/model-privacy-notice-mpn).
+
+**Rate Limiting and Data Refresh**
+
+Medicare Part A and B claims data will be refreshed weekly, Part D data monthly.
+
+Our schedules may vary depending on many things like maintenance, delayed delivery of claims to the CCW data warehouse, or additional data quality processing that's needed.
+
+We recommend you have a daily or weekly job to fetch new claims data for your users.  Please be responsible with your API usage and comply with the Service Management Rights to Limit conditions in the [Blue Button API Terms of Service](/terms).
+
+**Use of the Blue Button Logo**
+
+The Blue Button logo and usage guidelines is detailed [here](https://www.healthit.gov/patients-families/blue-button/blue-button-image).
+
+**Beneficiary Revokes Access**
+
+A beneficiary may revoke access to your application via the MyMedicare.gov website.  When you encounter an invalid token indicating a beneficiary has revoked access, you should make a reasonable attempt to handle that case making it easy for the beneficiary to understand what is happening with their Medicare data.
 
 ---
 

--- a/_pages/terms.md
+++ b/_pages/terms.md
@@ -1,0 +1,92 @@
+---
+layout: terms
+title:  "API Terms of Service"
+date:   2018-02-22 09:21:12 -0500
+description:
+landing-page: live
+gradient: "blueberry-lime-background"
+subnav-link-gradient: "blueberry-lime-link"
+badge: api
+permalink: "/terms/"
+sections:
+  - Overview
+  - Data Rights and Usage
+  - Attribution
+  - Service Management
+  - Liability
+ctas:
+  -
+    title: View the documentation
+    link: /developers
+  -
+    title: Sign up for the Developer Preview
+    link: https://sandbox.bluebutton.cms.gov/v1/accounts/create
+
+---
+
+## Overview
+If you've found yourself on this page, it's because you're interested in building software that helps the more than 57 million Medicare beneficiaries in the United States.  Thank you.  
+
+Please read our API Terms of Use carefully and post any questions you may have to the [Google Group](https://groups.google.com/forum/#!forum/Developer-group-for-cms-blue-button-api).
+
+By accessing or using Centers for Medicare & Medicaid Services ("CMS”) APIs and other developer services (collectively, "APIs"), you are agreeing to the terms below, as well as any relevant sections of [CMS's Website Policies](https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/Privacy-Policy.html) (collectively, Terms or Agreement).
+
+**Scope**
+
+The service (“API”) through which you interact with CMS data is subject to these Terms. Use of the API constitutes acceptance of these Terms.
+
+## Data Rights and Usage
+
+**Accounts/Registration**
+
+If you are using the API on behalf of an entity, you represent and warrant that you have authority to bind that entity to the Terms and by accepting the Terms, you are doing so on behalf of that entity (and all references to "you" in the Terms refer to you and that entity).
+
+In order to access the API you may be required to provide certain information (such as identification or contact details) as part of the registration process for the API, or as part of your continued use of the API. Any registration information you give to CMS must be accurate and up to date and you must inform us promptly of any updates so that we can keep you informed of any changes to the API or the Terms which may impact your usage of the API.
+
+Developer credentials (such as passwords, keys, tokens, and client IDs) issued to you by CMS are intended to be used only by you and to identify any software which you are using with the APIs. You agree to keep your credentials confidential and make reasonable efforts to prevent and discourage other persons from using your credentials. Developer credentials may not be embedded in open source projects.
+
+You will only access (or attempt to access) an API by the means described in the documentation of that API. If CMS assigns you developer credentials (e.g., client IDs), you must use them with the applicable APIs.
+
+**Privacy**
+
+You may use a CMS API to develop a service to search, display, analyze, retrieve, view and otherwise ‘get’ information from CMS data, which may be subject to the Privacy Act of 1974, the Health Insurance Portability and Accountability Act (HIPAA), and other laws, and require special safeguarding. You agree to strictly abide by all applicable federal and state laws regarding the protection and disclosure of information obtained through a CMS API.
+
+You further acknowledge that when records regarding an individual are obtained through a CMS API, you may not expose that content to other individuals or third parties without specific, explicit consent from the individual or his or her authorized representative. The terms “individual” and “record” have the meanings given in the Privacy Act at 5 U.S.C. § 552a(a). If you would like more information about the application of the Privacy Act at CMS, [click here](https://www.cms.gov/Research-Statistics-Data-and-Systems/Computer-Data-and-Systems/Privacy/PrivacyActof1974.html).
+
+## Attribution
+
+While not required, when using content, data, documentation, code, and related materials associated with the API in your own work, we ask that proper credit be given.  All services which utilize or access the API should display the following notice prominently within the application: “This product uses the [CMS Data API] but is not endorsed or certified by CMS or the U.S. Department of Health and Human Services.” You may use CMS’s name or logo in order to identify the source of API content subject to these Terms. You may not use the CMS name, logo, or the like to imply endorsement of any product, service, or entity, not-for-profit, commercial or otherwise.
+
+[Blue Button branding guidelines](/developers/#branding-guidelines)
+
+## Service Management
+
+**Right to Limit**
+
+Your use of the API may be subject to certain limitations on access, calls, or use as set forth within this Agreement or otherwise provided by CMS. These limitations are designed to manage the load on the system, promote equitable access, and prevent abuse, and these limitations may be adjusted without notice, as deemed necessary by CMS. If CMS reasonably believes that you have attempted to exceed or circumvent these limits, your ability to use the API may be temporarily or permanently blocked. CMS may monitor your use of the API to improve the service or to ensure compliance with this Agreement.
+
+**Service Termination**
+
+If you wish to terminate this Agreement, you may do so by refraining from further use of the API. CMS reserves the right (though not the obligation) to: (1) refuse to provide the API to you, if it is CMS's opinion that use violates any CMS policy; or (2) terminate or deny you access to and use of all or part of the API at any time for any other reason which in its sole discretion it deems necessary to in order to prevent abuse. You may petition CMS to regain access to the API through the support email address provided by CMS for the API. If CMS determines in its sole discretion that the circumstances which led to the refusal to provide the API or terminate access to the API no longer exist, then CMS may restore your access. All provisions of this Agreement, which by their nature should survive termination, shall survive termination including, without limitation, warranty disclaimers, and limitations of liability.
+
+## Liability
+
+**Disclaimer of Warranties**
+
+The API platform is provided "as is" and on an "as-available" basis. While we will do our best to ensure the service is available and functional at all times, CMS hereby disclaims all warranties of any kind, express or implied, including without limitation the warranties of merchantability, fitness for a particular purpose, and non-infringement. CMS makes no warranty that data will be error free or that access thereto will be continuous or uninterrupted.
+
+**Limitations on Liability**
+
+In no event will CMS or the U.S. Department of Health and Human Services (HHS) be liable with respect to any subject matter of this Agreement under any contract, negligence, strict liability or other legal or equitable theory for: (1) any special, incidental, or consequential damages; (2) the cost of procurement of substitute products or services; or (3) for interruption of use or loss or corruption of data.
+
+**Disputes, Choice of Law, Venue, and Conflicts**
+
+Any disputes arising out of this Agreement and access to or use of the API shall be governed by the laws and common law of the United States of America, including without limitation such regulations as may be promulgated from time to time by CMS, HHS, or any of its constituent agencies, without regard to any conflict of laws statutes or rules.  You further agree and consent to the jurisdiction of the Federal Courts located within the District of Columbia and the courts of appeal therefrom, and waive any claim of lack of jurisdiction or forum non conveniens. Some APIs may have API-specific terms of use. If there is a conflict between these Terms and additional terms applicable to a specific API, the  terms applicable to the specific API will control.
+
+**Indemnification**
+
+You agree to indemnify and hold harmless HHS, including CMS, its contractors, employees, agents, and the like, from and against any and all claims and expenses, including attorney’s fees, arising out of your use of the API, including but not limited to violation of this Agreement.
+
+**No Waiver of Rights**
+
+CMS's failure to exercise or enforce any right or provision of this Agreement shall not constitute waiver of such right or provision.


### PR DESCRIPTION
@aviars Can you give the Terms and Developer Guidelines a quick read?  The Terms copy has not changed, just bringing into the new layout.  The Developer Guidelines page is new and will continue to improve after this first version.

We will need to update the link to the Terms in the Dev Portal / Register App view.