### PR TITLE
508 changes

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,8 +3,7 @@
   <div class="ds-l-container ds-u-display--flex ds-u-justify-content--between ds-u-align-items--center">
     <div class="ds-u-justify-content--start ds-u-display--flex">
       <nav class="other-main-nav ds-u-font-weight--bold">
-        <h5 class="sr-only" id="desktop-nav">Main site navigation</h5>
-        <ul aria-labelledby="desktop-nav">
+        <ul>
           <li aria-label="CMS Blue Button API logo">
             {% include blue-button-logo.svg %}
             <a href="{{ "/blue button api" | relative_url }}" > </a>


### PR DESCRIPTION
Deleted <h5 class="sr-only" id="desktop-nav">Main site navigation</h5>` and the `aria-labelledby="desktop-nav"` from the <ul> beneath it, per 508 feedback on 2/27