### PR TITLE
CBBP-1058: BUG - fix jekyll site.url missing in test

### DIFF
--- a/_config-prod.yml
+++ b/_config-prod.yml
@@ -1,1 +1,2 @@
 tealium_env: "prod"
+url: "https://bluebutton.cms.gov" # the base hostname & protocol for your site, e.g. http://example.com

--- a/_config-test.yml
+++ b/_config-test.yml
@@ -1,1 +1,2 @@
 tealium_env: "dev"
+url: "http://test.bluebutton.cms.gov.s3-website-us-east-1.amazonaws.com"


### PR DESCRIPTION
Adding url to _config-prod and _config-test files to set to host name.

ONLY deploy to TEST for now.