### PR TITLE
Updates _config.yml to minify compiled CSS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,7 @@ plugins:
   - jekyll-feed
 
 sass:
+  style: compressed
   load_paths:
       - _sass
       - node_modules


### PR DESCRIPTION
So this should do the trick to minify the `main.css` file in the Jekyll build. The only thing that is weird about this is that the minified CSS is not showing up as a change, even though I can verify locally that the CSS file is now minified. But I'm thinking that maybe this just happens in the build process?

It might be worth merging to test, but let me know if you have any questions or concerns about this.