### PR TITLE
Adds cssurl var and updates readme and head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bluebutton-css
 _site
 .sass-cache
 .jekyll-metadata

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ It is assumed that the environment already has these installed:
 ## Build
 Jekyll builds the CSS and HTML pages. Run `bundle exec jekyll serve` from the project root for a local build. By default, the site will run in `http://localhost:4000/`. You can also run `bundle exec jekyll build` to compile the site files into the `_site` directory.
 
+## Get CSS/Styles Working
+We've moved the CSS for this application and our Sandbox application into a consolidated [Blue Button CSS repository](https://github.com/CMSgov/bluebutton-css) so that we can more easily keep things consistent and deploy changes more quickly.
+
+You'll need to clone/download the BlueButton CSS repository to get started. If you're using a terminal on a Mac/Linux machine, navigate into the `bluebutton-site-static` repository and then run the following command:
+
+```bash
+git clone git@github.com:CMSgov/bluebutton-css.git
+```
+
+If you need to make CSS changes, make them within this directory and commit them to that repository. These changes will be ignored by the git status of the `bluebutton-site-static` project, but you will see any CSS changes take effect locally.
+
+For more instructions on how to make changes, view the readme inside of the `bluebutton-css` directory.
+
 ## Deploy
 
 Use the [deploy static site](https://cloudbeesjenkins.cms.gov/dev-master/job/Blue%20Button/job/deploy%20static%20site/) job.

--- a/_config-prod.yml
+++ b/_config-prod.yml
@@ -4,3 +4,7 @@ url: "https://bluebutton.cms.gov" # the base hostname & protocol for your site, 
 # Define "use_dot_html" = true in environment _config file
 # default should be false i.e. not defined
 use_dot_html: true
+
+# CSS REPO TRIGGER
+# This is the prod URL for the CSS repo on AWS
+cssurl: https://s3.amazonaws.com/content-prod-bluebutton-cms-gov/static/statsite/assets/main.css

--- a/_config-test.yml
+++ b/_config-test.yml
@@ -4,3 +4,7 @@ url: "http://test.bluebutton.cms.gov.s3-website-us-east-1.amazonaws.com"
 # Define "use_dot_html" = true in environment _config file
 # default should be false i.e. not defined
 use_dot_html: true
+
+# CSS REPO TRIGGER
+# This is the test URL for the CSS repo on AWS
+cssurl: https://s3.amazonaws.com/test.bluebutton.cms.gov/assets/css/static-main.css

--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,10 @@ description: > # this means to ignore newlines until "baseurl:"
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
+# CSS REPO TRIGGER
+# By default, this will look for CSS files locally here. For Test and Prod, this URL is updated to point to AWS
+cssurl: bluebutton-css/dist/static-main.css
+
 # permalink: /blog/:title/
 permalink: /blog/:title
 # Build settings

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,13 +18,15 @@
   <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
 
   <link rel="shortcut icon" type="image/x-icon"  href="{{ '/assets/img/favicon.ico' | relative_url }}" />
-  <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ '/feed.xml' | relative_url }}">
   <link href='https://bluebutton.cms.gov/feed.xml' rel='alternate' type='application/atom+xml'>
 
+  <link rel="stylesheet" href="{{ site.cssurl }}" />
+
   <script>
-  window.tealiumEnvironment = "{{ site.tealium_env }}";
+    window.tealiumEnvironment = "{{ site.tealium_env }}";
   </script>
+  
   <script src="//tags.tiqcdn.com/utag/cmsgov/cms-bluebutton/prod/utag.sync.js"></script>
 </head>


### PR DESCRIPTION
The purpose of this update is to have the ability to pull the CSS Repo into this project, see local changes, and still ensure that on the test environment and prod the site is looking in the right place for the CSS.

In the `config.yml` file, I added the path to the local CSS files, assuming that the user has the CSS repo cloned at the root of this project. I added those instructions to the README as well to make sure new users would know to do that.

I then updated the `config-test.yml` and `config-prod.yml` file to point to the correct files from s3. I can't test that this works until we actually deploy it to test and then we can see if the URL matches, but I think this will work.