### PR TITLE
551 - Cleans up and fixes blog post header

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -31,7 +31,7 @@ layout: default
                   {% endif %}
                 {% endfor %}
 
-                <!-- Post Categories -->
+                <!-- Post Categories - Removed for Now -->
                 <!-- <div class="ds-u-l-display--white ds-u-margin-y--2">
                   {% if post %}
                     {% assign categories = post.categories %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,21 +6,47 @@ layout: default
     <div class="solid-container ds-u-padding-y--1 ds-u-lg-padding-y--1">
       <div class="ds-l-container">
         <div class="ds-l-row">
-          <div class="ds-u-color--white ds-l-sm-cold--12 ds-l-xl-col--10 ds-u-margin-left--auto">
-              <div class="ctas">
-                  {% for item in page.ctas limit:3 %}
-                      {% if item.link contains '://' %}<a class="ds-c-button button--white" href="{{ item.link }}" aria-label="{{ item.title }}" target="_blank">{{ item.title }}</a>
-                      {% else %}<a class="ds-c-button button--white" href="{{ item.link }}" aria-label="{{ item.title }}" target="_self" >{{ item.title }}</a>{% endif %}
-                  {% endfor %}
-                  <p class="ds-u-l-display--white">
-                      {% if post %}{% assign categories = post.categories %}{% else %}{% assign categories = page.categories %}{% endif %}
-                      {% if categories %}Categories:&nbsp;{% endif %}
-                      {% for category in categories %}<a href="{{site.baseurl}}/categories.html#{{category|slugize}}" class="ds-u-color--white">[{{ category }}]</a>&nbsp;
-                      {% endfor %}</p>
-              </div>
-              {% if page.badge %}<span class="ds-c-badge ds-u-text-transform--uppercase">{{ page.badge | escape }}</span>{% endif %}
-              <h3 class="ds-display">{{ page.title | escape }}</h3>
+          <div class="ds-u-color--white ds-l-sm-col--12 ds-l-xl-col--10 ds-u-margin-left--auto">
+
+              <!-- Page Badge -->
+              {% if page.badge %}
+                <span class="ds-c-badge ds-u-text-transform--uppercase ds-u-margin-y--2">
+                  {{ page.badge | escape }}
+                </span>
+              {% endif %}
+
+              <!-- Page Title -->
+              <h1 class="ds-display ds-u-leading--reset">{{ page.title | escape }}</h1>
+
+              <!-- Page Description -->
               {% if page.description %}<p class="ds-text--lead">{{ page.description | escape }}</p>{% endif %}
+
+              <!-- Call to Action Buttons -->
+              <div class="ctas ds-u-margin-y--4">
+                {% for item in page.ctas limit:3 %}
+                  {% if item.link contains '://' %}
+                    <a class="ds-c-button button--white" href="{{ item.link }}" aria-label="{{ item.title }}" target="_blank">{{ item.title }}</a>
+                  {% else %}
+                    <a class="ds-c-button button--white" href="{{ item.link }}" aria-label="{{ item.title }}" target="_self" >{{ item.title }}</a>
+                  {% endif %}
+                {% endfor %}
+
+                <!-- Post Categories -->
+                <!-- <div class="ds-u-l-display--white ds-u-margin-y--2">
+                  {% if post %}
+                    {% assign categories = post.categories %}
+                  {% else %}
+                    {% assign categories = page.categories %}
+                  {% endif %}
+                  {% if categories %}
+                    Post Categories:&nbsp;
+                  {% endif %}
+                  {% for category in categories %}
+                    <a href="{{site.baseurl}}/categories.html#{{category|slugize}}" class="ds-u-color--white">{{ category }}</a>&nbsp;
+                  {% endfor %}
+                </div> -->
+
+              </div>
            </div>
         </div>
       </div>


### PR DESCRIPTION
So, this tries to organize the `post.html` a bit. Here is a summary of the changes:
- Moved the buttons below the title
- Spaced out the code a bit and added comments.
- Made the title in the banner a `<h1>` tag for accessibility reasons. We typically don't want to have an `<h3>` before a `<h1> ` tag. This means that some pages will have two `<h1>` tags, but we can fix that in a different issue.
- For now, I commented out the `Category` links. We have a ton of posts that are marked as `latest` that obviously aren't the latest. I think those can be cleaned up, it is just less confusing to remove them, especially since you can filter by them at the bottom of the page.

This is what the updated header looks like locally:

![screenshot_2018-11-02 install a ruby on rails client app](https://user-images.githubusercontent.com/5551607/47929679-2ca5d800-dea0-11e8-8631-24d66dbe3ac1.png)
