### PR TITLE
616 Mobile Nav IE 11 Fix

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -33,7 +33,7 @@ const closeNavOnResize = function(e) {
 window.addEventListener('resize', closeNavOnResize);
 
 // Add the click ation to the mobile nav trigger
-mobileNavTriggerButton.addEventListener('click', () => {
+mobileNavTriggerButton.addEventListener('click', function () {
   mobileNavContainer.classList.toggle('is-visible');
   mobileNavTriggerButton.classList.toggle('trigger-active');
   // Set up toggle for the menu icon and text


### PR DESCRIPTION
Since we don't have Babel in place yet, I just went ahead and reverted the one arrow function to a regular function to see if that will fix the problem with IE 11.

The problem is that when the "Menu" button is clicked, nothing happens.