### PR TITLE
BLUEBUTTON-736 - Adds anchor to blog post.

### DIFF
--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -45,7 +45,7 @@ To use the Blue Button OAuth 2 a developer must [register their application](htt
 
 A registered application is given a client ID and a client secret. The secret should only be used if it can be kept confidential, such as communication between your server and the Blue Button API. Otherwise the [Client Application Flow](#client-application-flow) may be used.
 
-### Native Mobile App Support
+### Native Mobile App Support {#nativeMobileApp}
 
 Native Mobile App Support follows the [RFC 8252 - OAuth 2.0 for Native Apps](https://tools.ietf.org/html/rfc8252) authentication flow utilizing the [PKCE](https://tools.ietf.org/html/rfc7636) extension and enables a custom URI scheme redirect.
 

--- a/_posts/2019-02-07-introducing-native-mobile-app-support.md
+++ b/_posts/2019-02-07-introducing-native-mobile-app-support.md
@@ -53,13 +53,13 @@ For mobile app developers this allows integration with the Blue Button 2.0 API t
 
 ## How to Get Started with Native Mobile App Support
 
-Find documentation on Native Mobile App Support in the [Blue Button documentation](https://bluebutton.cms.gov/developers/).
+Find documentation on Native Mobile App Support in the [Blue Button documentation](https://bluebutton.cms.gov/developers/#nativeMobileApp).
 
 A coding example of an OAuth 2.0 and PKCE flow is available here: [Authorization Code with PKCE Flow - OAuth 2.0 Playground](https://www.oauth.com/playground/authorization-code-with-pkce.html)
 
 The Blue Button 2.0 engineering team has also created a sample Android application. You can review or fork the code here: [https://github.com/CMSgov/bluebutton-sample-client-android](https://github.com/CMSgov/bluebutton-sample-client-android)
 
-We are excited to release this new capability and look forward to seeing the exciting things you create. You can share what you’re working on and any feedback you have on the [Google Group](https://groups.google.com/forum/#!forum/Developer-group-for-cms-blue-button-api). 
+We are excited to release this new capability and look forward to seeing the exciting things you create. You can share what you’re working on and any feedback you have on the [Google Group](https://groups.google.com/forum/#!forum/Developer-group-for-cms-blue-button-api).
 
 
 ---


### PR DESCRIPTION
Now, in the blog post, when you click on the "Blue Button Documentation" link - you will be taken right to that section in the documentation.