### PR TITLE
BLUEBUTTON-920 Removes references to Slack on the Support page

### DIFF
--- a/_layouts/support.html
+++ b/_layouts/support.html
@@ -23,7 +23,7 @@ layout: default
 		<article class="ds-l-col--12">
 			<h2>Get Social!</h2>
 			<p>
-				If the Google Group doesn't quite meet your needs or you have a more general question about Blue Button, you can always reach out to our community on Twitter with the hashtag <a href="https://twitter.com/hashtag/bluebutton?lang=en">#bluebutton</a>.
+				If the Google Group doesn't quite meet your needs, you can always reach out to our community on Twitter with the hashtag <a href="https://twitter.com/hashtag/bluebutton?lang=en">#bluebutton</a>.
 			</p>
 		</article>
 

--- a/_layouts/support.html
+++ b/_layouts/support.html
@@ -7,23 +7,13 @@ layout: default
   <div class="ds-l-row">
 
     <!-- Google Group Section -->
-    <article class="ds-l-col--12 ds-l-sm-col--12 ds-l-md-col--6 ds-l-lg-col--6 ds-l-xl-col--6 ds-u-margin-bottom--2 {{ page.badge | slugify }}" id="main" role="main">
+    <article class="ds-l-col--12 ds-l-sm-col--12 ds-l-md-col--12 ds-l-lg-col--12 ds-l-xl-col--12 ds-u-margin-bottom--2 {{ page.badge | slugify }}" id="main" role="main">
 			<img src="{{ site.baseurl }}/assets/img/support/google-logo.svg" alt="Google logo" />
 			<h2>Blue Button 2.0 Google Group</h2>
 			<p>
 				The Google Group is one of the best places to get your questions answered by the Blue Button 2.0 team. Our community of developers use the Google Group to share their issues, answer each other’s questions, and propose future features.
 			</p>
 			<a href="https://groups.google.com/forum/#!forum/Developer-group-for-cms-blue-button-api" class="ds-c-button ds-c-button--primary">Visit the Google Group</a>
-		</article>
-
-		<!-- Slack Section -->
-		<article class="ds-l-col--12 ds-l-sm-col--12 ds-l-md-col--6 ds-l-lg-col--6 ds-l-xl-col--6 ds-u-margin-bottom--2" {{ page.badge | slugify }}>
-			<img src="{{ site.baseurl }}/assets/img/support/slack-logo.svg" alt="Slack logo" />
-			<h2>Blue Button 2.0 Slack Channel</h2>
-			<p>
-				Another option for getting support is our public Blue Button Slack. If Slack is part of your workflow, you can sign up and pop in anytime to ask a question or strike up a conversation with other Blue Button 2.0 developers.
-			</p>
-			<a href="https://bluebutton2.slack.com/join/shared_invite/enQtNDY2MTgzNDI3MjgxLWFhNzcxY2M2MmNiOGM4ZmY4MjljNzFhNjdmNmMzMmFhZDNjMzM3Zjg2NTNkYTFkOWIzZjhjYWFlNmNiZmFmODc" class="ds-c-button ds-c-button--primary">Connect Via Slack</a>
 		</article>
 
 	</div>
@@ -33,7 +23,7 @@ layout: default
 		<article class="ds-l-col--12">
 			<h2>Get Social!</h2>
 			<p>
-				If none of these options quite meet your needs, you can always reach out to our community on Twitter with the hashtag <a href="https://twitter.com/hashtag/bluebutton?lang=en">#bluebutton</a>.
+				If the Google Group doesn't quite meet your needs or you have a more general question about Blue Button, you can always reach out to our community on Twitter with the hashtag <a href="https://twitter.com/hashtag/bluebutton?lang=en">#bluebutton</a>.
 			</p>
 		</article>
 


### PR DESCRIPTION
This takes care of the static site portion of this ticket.