### PR TITLE
Add Slack Notices for Static Site Pipeline

### DIFF
--- a/ops/Jenkinsfile
+++ b/ops/Jenkinsfile
@@ -1,5 +1,6 @@
 #!groovy
 def aws_creds = 'cbj-deploy'
+def helpers
 
 pipeline {
   agent any
@@ -36,7 +37,7 @@ pipeline {
     stage('Notify') {
       steps {
         script {
-          helpers = load "Jenkinsfiles/helpers.groovy"
+          helpers = load "ops/helpers.groovy"
           helpers.slackNotify "STARTING"
         }
       }

--- a/ops/Jenkinsfile
+++ b/ops/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
   }
 
   stages {
-    stage('Notify') {
+/*    stage('Notify') {
       steps {
         script {
           helpers = load "ops/helpers.groovy"
@@ -47,7 +47,7 @@ pipeline {
       steps {
         deleteDir()
       }
-    }
+    }*/
 
     stage('Checkout Static Site') {
       steps {
@@ -229,7 +229,7 @@ pipeline {
   }
 
 
-  post {
+/*  post {
       success {
         script {
           helpers.slackNotify("SUCESS", 'good')
@@ -250,5 +250,5 @@ pipeline {
         // Cleanup the workspace
         deleteDir()
       }
-  }
+  }*/
 }

--- a/ops/Jenkinsfile
+++ b/ops/Jenkinsfile
@@ -33,23 +33,11 @@ pipeline {
   }
 
   stages {
-    stage('Notify HipChat') {
+    stage('Notify') {
       steps {
-        withCredentials([
-          string(credentialsId: 'hipchat-room', variable: 'room'),
-          string(credentialsId: 'hipchat-server', variable: 'server'),
-          string(credentialsId: 'hipchat-token', variable: 'token')
-        ]) {
-          hipchatSend(
-            color: 'GRAY',
-            notify: true,
-            message: "SUCCESS: ${env.JOB_NAME} [staging: ${params.DEPLOY_STAGING}] [prod: ${params.DEPLOY_PROD}]",
-            room: room,
-            sendAs: '',
-            server: server,
-            token: token,
-            v2enabled: true
-          )
+        script {
+          helpers = load "Jenkinsfiles/helpers.groovy"
+          helpers.slackNotify "STARTING"
         }
       }
     }
@@ -241,42 +229,25 @@ pipeline {
 
 
   post {
-    success {
-      withCredentials([
-        string(credentialsId: 'hipchat-room', variable: 'room'),
-        string(credentialsId: 'hipchat-server', variable: 'server'),
-        string(credentialsId: 'hipchat-token', variable: 'token')
-      ]) {
-        hipchatSend(
-            color: 'GREEN',
-            notify: true,
-            message: "SUCCESS: ${env.JOB_NAME} [staging: ${params.DEPLOY_STAGING}] [prod: ${params.DEPLOY_PROD}]",
-            room: room,
-            sendAs: '',
-            server: server,
-            token: token,
-            v2enabled: true
-        )
+      success {
+        script {
+          helpers.slackNotify("SUCESS", 'good')
+        }
       }
-    }
 
-    failure {
-      withCredentials([
-        string(credentialsId: 'hipchat-room', variable: 'room'),
-        string(credentialsId: 'hipchat-server', variable: 'server'),
-        string(credentialsId: 'hipchat-token', variable: 'token')
-      ]) {
-        hipchatSend(
-          color: 'RED',
-          notify: true,
-          message: "FAILED: ${env.JOB_NAME} [prod: ${params.DEPLOY_PROD}]",
-          room: room,
-          sendAs: '',
-          server: server,
-          token: token,
-          v2enabled: true
-        )
+      failure {
+        script {
+          try {
+            helpers.slackNotify("FAILED!", 'bad')
+          } catch (err) {
+            emailext body: "A CBJ job failed and we couldn't notify Slack.\n${BUILD_URL}", subject: 'CBJ Build Failure', to: 'bluebutton-dev-alert@fearsol.com'
+          }
+        }
       }
-    }
+
+      always {
+        // Cleanup the workspace
+        deleteDir()
+      }
   }
 }


### PR DESCRIPTION
This removes the hipchat notices and enabled slack notices for pipeline jobs in regards to the static site. 