### PR TITLE
BLUEBUTTON-1610: Add slack notices for Static Site Pipeline

### DIFF
--- a/ops/Jenkinsfile
+++ b/ops/Jenkinsfile
@@ -228,7 +228,6 @@ pipeline {
     }
   }
 
-
   post {
     success {
       script {

--- a/ops/Jenkinsfile
+++ b/ops/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
     stage('Notify') {
       steps {
         script {
-          helpers = load "Jenkinsfiles/helpers.groovy"
+          helpers = load "ops/helpers.groovy"
           helpers.slackNotify "STARTING"
         }
       }

--- a/ops/Jenkinsfile
+++ b/ops/Jenkinsfile
@@ -1,5 +1,6 @@
 #!groovy
 def aws_creds = 'cbj-deploy'
+def helpers
 
 pipeline {
   agent any
@@ -33,23 +34,11 @@ pipeline {
   }
 
   stages {
-    stage('Notify HipChat') {
+    stage('Notify') {
       steps {
-        withCredentials([
-          string(credentialsId: 'hipchat-room', variable: 'room'),
-          string(credentialsId: 'hipchat-server', variable: 'server'),
-          string(credentialsId: 'hipchat-token', variable: 'token')
-        ]) {
-          hipchatSend(
-            color: 'GRAY',
-            notify: true,
-            message: "SUCCESS: ${env.JOB_NAME} [staging: ${params.DEPLOY_STAGING}] [prod: ${params.DEPLOY_PROD}]",
-            room: room,
-            sendAs: '',
-            server: server,
-            token: token,
-            v2enabled: true
-          )
+        script {
+          helpers = load "Jenkinsfiles/helpers.groovy"
+          helpers.slackNotify "STARTING"
         }
       }
     }
@@ -242,41 +231,24 @@ pipeline {
 
   post {
     success {
-      withCredentials([
-        string(credentialsId: 'hipchat-room', variable: 'room'),
-        string(credentialsId: 'hipchat-server', variable: 'server'),
-        string(credentialsId: 'hipchat-token', variable: 'token')
-      ]) {
-        hipchatSend(
-            color: 'GREEN',
-            notify: true,
-            message: "SUCCESS: ${env.JOB_NAME} [staging: ${params.DEPLOY_STAGING}] [prod: ${params.DEPLOY_PROD}]",
-            room: room,
-            sendAs: '',
-            server: server,
-            token: token,
-            v2enabled: true
-        )
+      script {
+        helpers.slackNotify("SUCCESS", 'good')
       }
     }
 
     failure {
-      withCredentials([
-        string(credentialsId: 'hipchat-room', variable: 'room'),
-        string(credentialsId: 'hipchat-server', variable: 'server'),
-        string(credentialsId: 'hipchat-token', variable: 'token')
-      ]) {
-        hipchatSend(
-          color: 'RED',
-          notify: true,
-          message: "FAILED: ${env.JOB_NAME} [prod: ${params.DEPLOY_PROD}]",
-          room: room,
-          sendAs: '',
-          server: server,
-          token: token,
-          v2enabled: true
-        )
+      script {
+        try {
+          helpers.slackNotify("FAILED!", 'bad')
+        } catch (err) {
+          emailext body: "A CBJ job failed and we couldn't notify Slack.\n${BUILD_URL}", subject: 'CBJ Build Failure', to: 'bluebutton-dev-alert@fearsol.com'
+        }
       }
+    }
+
+    always {
+      // Cleanup the workspace
+      deleteDir()
     }
   }
 }

--- a/ops/helpers.groovy
+++ b/ops/helpers.groovy
@@ -1,0 +1,29 @@
+#!/usr/bin/env groovy
+
+// Send a message to Slack
+def slackNotify(message, status='unknown', channel='blue-button-api-alert') {
+  switch (status) {
+    case 'good':
+      slack_color = 'good'
+      break
+    case 'bad':
+      slack_color = 'danger'
+      break
+    default:
+      slack_color = null
+      break
+  }
+
+  withCredentials([string(credentialsId: 'bb20-slack-token', variable: 'slack_token')]) {
+    if (env.DISABLE_SLACK_ALERTS != 'true') {
+      slackSend message: "${message}\n${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)",
+        color: slack_color,
+        failOnError: false,
+        teamDomain: 'cmsgov',
+        channel: channel,
+        token: slack_token
+    }
+  }
+}
+
+return this


### PR DESCRIPTION
What: 

Add slack notices to static site pipeline job. 

Why:

So we can use a 'chatops' style of monitoring this job. 

How:
I've ported the slack notices pipeline syntax and the helper file to the static site repo and jenkins pipeline. Notices of start, success and failed are sent. Tested directly. 