### PR TITLE
Adds context to error message about missing claims data

### DIFF
--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -702,6 +702,10 @@ The Blue Button logo and usage guidelines is detailed [here](https://www.healthi
 
 A beneficiary may revoke access to your application via the MyMedicare.gov website.  When you encounter an invalid token indicating a beneficiary has revoked access, you should make a reasonable attempt to handle that case making it easy for the beneficiary to understand what is happening with their Medicare data.
 
+**"Blue Button doesn't have any claims data for you just yet. Please try again later."**
+
+If Blue Button does not have data for a beneficiary, they will not be able to authorize access to the API, and will see the error message above.
+
 ---
 
 ## Blue Button Implementation Guide


### PR DESCRIPTION
For the error message:
```
Blue Button doesn't have any claims data for you just yet. Please try again later.
```

We added the following copy to the documentation:

`If Blue Button does not have data for a beneficiary, they will not be able to authorize access to the API, and will see the error message above.`
