### PR TITLE
Removes incident message from the homepage now that it has been remed…

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,18 +37,6 @@ ctas:
 		</div>
 	</a>
 </div> -->
-
-<div class="ds-c-alert ds-c-alert--warn">
-    <div class="ds-c-alert__body">
-      <h3 class="ds-c-alert__heading">Important Announcement</h3>
-      <p class="ds-c-alert__text">
-			CMS has conducted a full review of Blue Button 2.0, corrected the faulty code, implemented additional protections, and is resuming normal operations of the system. You can find more information on the technical issue that was addressed on the <a href="{{ site.baseurl }}/blog/bbapi-update.html">Blue Button 2.0 API Update</a> blog post.  
-			<br />
-			<br />
-			CMS is mailing letters to all affected beneficiaries in the coming weeks. Beneficiaries who have questions can contact 1-800-MEDICARE at any time.
-      </p>
-    </div>
-  </div>
  
 ## Overview
 


### PR DESCRIPTION
During the data incident in December, we posted an update to the static site homepage. Now that the issue has been remediated and beneficiaries have been contacted, it is time to remove the message.

This change simply removes that message. 