### PR TITLE
BB2-218 - Highlight the "Try the API" section of the developer documentation

### DIFF
--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -10,10 +10,10 @@ badge: documentation
 permalink: "/developers/"
 sections:
   - Overview
+  - Try the API
   - Authorization
   - Core Resources
   - FHIR Data Model
-  - Try the API
   - Sample Beneficiaries
   - Production API Access
   - Developer Guidelines
@@ -36,6 +36,153 @@ The CMS Blue Button API:
 - Enables a developer to register a beneficiary-facing application
 - Enables a beneficiary to grant an application access to four years of their Part A, B, and D claims data
 - Uses the [HL7 FHIR](https://www.hl7.org/fhir/) standard for beneficiary data and the [OAuth 2.0](https://oauth.net/2/) standard for beneficiary authorization
+
+---
+
+## Try the API
+
+To join the Developer Sandbox, register a sample application and retrieve synthetic data for a sample Patient ID by calling the API, follow these four steps:
+
+**Step 1:** [Join the Developer Sandbox](https://sandbox.bluebutton.cms.gov/v1/accounts/create) and register a sample application
+
+Click "Add an Application" to register a new sample application and get a Client ID and Secret
+
+**Step 2:** Generate a sample token
+
+To test out the Blue Button API, you must first generate a sample token that represents a beneficiary granting consent.
+
+To see a sample of Blue Button data you can access the Test Client. 
+
+1.  If you are already logged in to the Developer portal, log out
+2.  In the navigation bar on [https://sandbox.bluebutton.cms.gov](https://sandbox.bluebutton.cms.gov) click on "Test Client"
+3.  Click "sample Authorization flow"
+4.	Click the Authorization Link to authorize
+5.  You will be redirected to MyMedicare.gov. Login with one of the synthetic beneficiary accounts
+
+	<div class="ds-c-alert ds-c-alert--hide-icon ds-u-margin-bottom--2">
+      <div class="ds-c-alert__body">
+        <h3 class="ds-c-alert__heading">Synthetic Beneficiary Accounts</h3>
+        <p class="ds-c-alert__text">
+          The first user is <strong>BBUser00000</strong> with password <strong>PW00000!</strong> and these sample users continue all the way to <strong>BBUser29999</strong> with password <strong>PW29999!</strong>
+          <i>Note: the ! at the end of the password is required</i>
+        </p>
+      </div>
+	</div>
+
+6.  Click "Allow" to Authorize sharing
+7.  Review the details returned from the Authorization flow
+8.  Make some API calls for the beneficiary account you used to authorize access
+
+
+**Step 3:** Call the API
+
+Try this out in Postman:
+
+1. 	From the Postman app, open a new tab
+2. 	Paste the Request URL: 
+	```
+	https://sandbox.bluebutton.cms.gov/v1/fhir/Patient/-20140000008325
+	```
+3. 	Click "Authorization" and select type "OAuth 2.0"
+4.  Click on "Get New Access Token"
+5.  Enter the following parameters:
+
+	**Token Name:** {The name of your app}
+
+	**Grant Type:** Authorization Code (unless you have chosen an alternate value for your app)
+
+	**Callback URL:** One of the redirect uris you registered for your app, for example:
+
+	```
+	http://localhost:3000
+	```
+
+	**Auth URL:** 
+
+	```
+	https://sandbox.bluebutton.cms.gov/v1/o/authorize/
+	```
+
+	**Access Token URL:** 
+
+	```
+	https://sandbox.bluebutton.cms.gov/v1/o/token/
+	```
+
+	**Client ID:** {The Client ID assigned to your App in the sandbox}
+
+	**Client Secret:** {The Client Secret assigned to your App in the sandbox}
+
+	**Scope:** 
+	```
+	patient/Patient.read patient/Coverage.read patient/ExplanationOfBenefit.read profile
+	```
+	
+	*NOTE:* When a beneficiary is authorizing your application, they will have the ability to omit the `patient/Patient.read` scope. **Be sure that you build your application accordingly to handle a 403 error if a beneficiary decides to filter their demographic information.**
+  
+	**State:** An optional value that you may use in your app
+
+	**Client Authentication:** Select "Send as Basic Auth header"
+
+6.  Click Request Token. You should see a pop up for the MyMedicare.gov. Login using one of the synthetic beneficiary accounts
+
+	<div class="ds-c-alert ds-c-alert--hide-icon ds-u-margin-bottom--2">
+    <div class="ds-c-alert__body">
+      <h3 class="ds-c-alert__heading">Synthetic Beneficiary Accounts</h3>
+      <p class="ds-c-alert__text">
+			The first user is <strong>BBUser00000</strong> with password <strong>PW00000!</strong> and these sample users continue all the way to <strong>BBUser29999</strong> with password <strong>PW29999!</strong>
+
+				<i>Note: the ! at the end of the password is required</i>
+      </p>
+    </div>
+	</div>
+
+7.  Authorize sharing by clicking "Allow" on the authorization screen
+8.  When you return to the Postman workspace you should now be able to make requests to the API using the Bearer Token that will have been placed in the Header
+7. 	Click "Send" and see the synthetic beneficiary's personal health information as a Patient FHIR Resource display under "Body" in Postman
+
+Once you have the Bearer Token you can also use Curl to make queries as follows:
+
+<pre>
+curl --header "Authorization: Bearer YOUR TOKEN HERE" https://sandbox.bluebutton.cms.gov/v1/fhir/Patient/-20140000008325
+</pre>
+
+
+**Step 4:** View the API Response
+
+In the API response for Patient -20140000008325 you will find:
+uests- 32 total claims (140 total claim lines)
+- 25 carrier claims (110 carrier claim lines)
+- 2 inpatient claims (25 inpatient claim lines)
+- 5 Part D events
+
+
+**Step 5:** Accessing Synthetic Data
+In order to access the full synthetic dataset for an individual synthetic beneficiary, 
+you can do the following:
+1. Set up your sandbox application
+2. Log out of [https://sandbox.bluebutton.cms.gov](https://sandbox.bluebutton.cms.gov).
+3. Access the authorization url at [https://sandbox.bluebutton.cms.gov/v1/o/authorize/](https://sandbox.bluebutton.cms.gov/v1/o/authorize/)
+
+    *Note: The last backslash is important*.
+    *Also remember to append ?client_id={your client_id assigned to the application you registered}*
+
+4. You will be redirected to the Medicare authentication screen on. DO NOT ACCESS THIS PAGE DIRECTLY.
+5. Use one of thirty thousand provided usernames and passwords.
+
+    <div class="ds-c-alert ds-c-alert--hide-icon ds-u-margin-bottom--2">
+      <div class="ds-c-alert__body">
+        <h3 class="ds-c-alert__heading">Synthetic Beneficiary Accounts</h3>
+        <p class="ds-c-alert__text">
+          The first user is <strong>BBUser00000</strong> with password <strong>PW00000!</strong> and these sample users continue all the way to <strong>BBUser29999</strong> with password <strong>PW29999!</strong>
+          <i>Note: the ! at the end of the password is required</i>
+        </p>
+      </div>
+	</div>
+
+6. Approve access for your application, which will now receive an access token, which can be used in the requests described above.
+
+7. The authorization completes when you are redirected back to the Redirect_URI you specified when you registered your application.
 
 ---
 
@@ -800,151 +947,6 @@ Today, there are approximately 38M beneficiaries in traditional or fee-for-servi
 Part D has always been a separate program, but certain plans include both the MA benefits (Part C) and Part D.  As a result, Part D drug event data is collected separately from MA encounter data.  Part D drug event data for all participants in Part D has been collected by the agency since the program began in the mid-2000s.  
 
 The API also has historical claims data going back four years.  All of these factors contribute to the 53M number we use to describe the total number of beneficiaries available via the Blue Button API.
-
-## Try the API
-
-To join the Developer Sandbox, register a sample application and retrieve synthetic data for a sample Patient ID by calling the API, follow these four steps:
-
-**Step 1:** [Join the Developer Sandbox](https://sandbox.bluebutton.cms.gov/v1/accounts/create) and register a sample application
-
-Click "Add an Application" to register a new sample application and get a Client ID and Secret
-
-**Step 2:** Generate a sample token
-
-To test out the Blue Button API, you must first generate a sample token that represents a beneficiary granting consent.
-
-To see a sample of Blue Button data you can access the Test Client. 
-
-1.  If you are already logged in to the Developer portal, log out
-2.  In the navigation bar on [https://sandbox.bluebutton.cms.gov](https://sandbox.bluebutton.cms.gov) click on "Test Client"
-3.  Click "sample Authorization flow"
-4.	Click the Authorization Link to authorize
-5.  You will be redirected to MyMedicare.gov. Login with one of the synthetic beneficiary accounts
-
-	<div class="ds-c-alert ds-c-alert--hide-icon ds-u-margin-bottom--2">
-      <div class="ds-c-alert__body">
-        <h3 class="ds-c-alert__heading">Synthetic Beneficiary Accounts</h3>
-        <p class="ds-c-alert__text">
-          The first user is <strong>BBUser00000</strong> with password <strong>PW00000!</strong> and these sample users continue all the way to <strong>BBUser29999</strong> with password <strong>PW29999!</strong>
-          <i>Note: the ! at the end of the password is required</i>
-        </p>
-      </div>
-	</div>
-
-6.  Click "Allow" to Authorize sharing
-7.  Review the details returned from the Authorization flow
-8.  Make some API calls for the beneficiary account you used to authorize access
-
-
-**Step 3:** Call the API
-
-Try this out in Postman:
-
-1. 	From the Postman app, open a new tab
-2. 	Paste the Request URL: 
-	```
-	https://sandbox.bluebutton.cms.gov/v1/fhir/Patient/-20140000008325
-	```
-3. 	Click "Authorization" and select type "OAuth 2.0"
-4.  Click on "Get New Access Token"
-5.  Enter the following parameters:
-
-	**Token Name:** {The name of your app}
-
-	**Grant Type:** Authorization Code (unless you have chosen an alternate value for your app)
-
-	**Callback URL:** One of the redirect uris you registered for your app, for example:
-
-	```
-	http://localhost:3000
-	```
-
-	**Auth URL:** 
-
-	```
-	https://sandbox.bluebutton.cms.gov/v1/o/authorize/
-	```
-
-	**Access Token URL:** 
-
-	```
-	https://sandbox.bluebutton.cms.gov/v1/o/token/
-	```
-
-	**Client ID:** {The Client ID assigned to your App in the sandbox}
-
-	**Client Secret:** {The Client Secret assigned to your App in the sandbox}
-
-	**Scope:** 
-	```
-	patient/Patient.read patient/Coverage.read patient/ExplanationOfBenefit.read profile
-	```
-	
-	*NOTE:* When a beneficiary is authorizing your application, they will have the ability to omit the `patient/Patient.read` scope. **Be sure that you build your application accordingly to handle a 403 error if a beneficiary decides to filter their demographic information.**
-  
-	**State:** An optional value that you may use in your app
-
-	**Client Authentication:** Select "Send as Basic Auth header"
-
-6.  Click Request Token. You should see a pop up for the MyMedicare.gov. Login using one of the synthetic beneficiary accounts
-
-	<div class="ds-c-alert ds-c-alert--hide-icon ds-u-margin-bottom--2">
-    <div class="ds-c-alert__body">
-      <h3 class="ds-c-alert__heading">Synthetic Beneficiary Accounts</h3>
-      <p class="ds-c-alert__text">
-			The first user is <strong>BBUser00000</strong> with password <strong>PW00000!</strong> and these sample users continue all the way to <strong>BBUser29999</strong> with password <strong>PW29999!</strong>
-
-				<i>Note: the ! at the end of the password is required</i>
-      </p>
-    </div>
-	</div>
-
-7.  Authorize sharing by clicking "Allow" on the authorization screen
-8.  When you return to the Postman workspace you should now be able to make requests to the API using the Bearer Token that will have been placed in the Header
-7. 	Click "Send" and see the synthetic beneficiary's personal health information as a Patient FHIR Resource display under "Body" in Postman
-
-Once you have the Bearer Token you can also use Curl to make queries as follows:
-
-<pre>
-curl --header "Authorization: Bearer YOUR TOKEN HERE" https://sandbox.bluebutton.cms.gov/v1/fhir/Patient/-20140000008325
-</pre>
-
-
-**Step 4:** View the API Response
-
-In the API response for Patient -20140000008325 you will find:
-uests- 32 total claims (140 total claim lines)
-- 25 carrier claims (110 carrier claim lines)
-- 2 inpatient claims (25 inpatient claim lines)
-- 5 Part D events
-
-
-**Step 5:** Accessing Synthetic Data
-In order to access the full synthetic dataset for an individual synthetic beneficiary, 
-you can do the following:
-1. Set up your sandbox application
-2. Log out of [https://sandbox.bluebutton.cms.gov](https://sandbox.bluebutton.cms.gov).
-3. Access the authorization url at [https://sandbox.bluebutton.cms.gov/v1/o/authorize/](https://sandbox.bluebutton.cms.gov/v1/o/authorize/)
-
-    *Note: The last backslash is important*.
-    *Also remember to append ?client_id={your client_id assigned to the application you registered}*
-
-4. You will be redirected to the Medicare authentication screen on. DO NOT ACCESS THIS PAGE DIRECTLY.
-5. Use one of thirty thousand provided usernames and passwords.
-
-    <div class="ds-c-alert ds-c-alert--hide-icon ds-u-margin-bottom--2">
-      <div class="ds-c-alert__body">
-        <h3 class="ds-c-alert__heading">Synthetic Beneficiary Accounts</h3>
-        <p class="ds-c-alert__text">
-          The first user is <strong>BBUser00000</strong> with password <strong>PW00000!</strong> and these sample users continue all the way to <strong>BBUser29999</strong> with password <strong>PW29999!</strong>
-          <i>Note: the ! at the end of the password is required</i>
-        </p>
-      </div>
-	</div>
-
-6. Approve access for your application, which will now receive an access token, which can be used in the requests described above.
-
-7. The authorization completes when you are redirected back to the Redirect_URI you specified when you registered your application.
 
 ---
 


### PR DESCRIPTION
This is another pretty straight-forward change. In an effort to get users up-and-running as quickly as possible with our API, we've moved the "Try the API" section to the top. This will hopefully help ensure that:

- Users are able to quickly register an application
- Users can take their application credentials and test using a tool like Postman or cURL.

This update does not make any changes to the content of the documentation, simply its presentation order. This update is the first in a series of iterative updates to the developer documentation that will aim to make it more user-friendly for the users who consume it.