### PR TITLE
BB2-231 Update references to Blue Button on the static website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Blue Button API
-A static Jekyll site for the Blue Button API splash page: [https://bluebutton.cms.gov](https://bluebutton.cms.gov/)
+# CMS Blue Button 2.0 API Static Site
+A static Jekyll site for the Blue Button 2.0 API splash page: [https://bluebutton.cms.gov](https://bluebutton.cms.gov/)
 
 ## Requirements
 It is assumed that the environment already has these installed:
@@ -15,7 +15,7 @@ It is assumed that the environment already has these installed:
 Jekyll builds the CSS and HTML pages. Run `bundle exec jekyll serve` from the project root for a local build. By default, the site will run in `http://localhost:4000/`. You can also run `bundle exec jekyll build` to compile the site files into the `_site` directory.
 
 ## Get CSS/Styles Working
-We've moved the CSS for this application and our Sandbox application into a consolidated [Blue Button CSS repository](https://github.com/CMSgov/bluebutton-css) so that we can more easily keep things consistent and deploy changes more quickly.
+We've moved the CSS for this application and our Sandbox application into a consolidated [Blue Button 2.0 API CSS repository](https://github.com/CMSgov/bluebutton-css) so that we can more easily keep things consistent and deploy changes more quickly.
 
 You'll need to clone/download the BlueButton CSS repository to get started. If you're using a terminal on a Mac/Linux machine, navigate into the `bluebutton-site-static` repository and then run the following command:
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
-title: CMS Blue Button API
+title: CMS Blue Button 2.0 API
 description: > # this means to ignore newlines until "baseurl:"
-  The CMS Blue Button API enables beneficiaries to connect their Medicare claims data to the applications, services, and research programs they trust.
+  The CMS Blue Button 2.0 API enables beneficiaries to connect their Medicare claims data to the applications, services, and research programs they trust.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
@@ -39,7 +39,7 @@ exclude:
 include: ["_pages"]
 
 # Settings for RSS Feed for Blog
-name: Blue Button 2.0 Blog
+name: Blue Button 2.0 API Blog
 # the next two values are defined above so we are changing the keys.
 blog_description: Updates, how-to guides, sample apps, and other useful content related to Blue Button 2.0 API
 blog_url: https://bluebutton.cms.gov

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-title:  "Blue Button Blog"
+title:  "Blue Button 2.0 API Blog"
 date:   2018-03-26 23:46:00 -0500
-description: The Blue Button Blog for Developers using Blue Button 2.0 API.
+description: The Blue Button 2.0 API Blog for Developers using Blue Button 2.0 API.
 landing-page: live
 gradient: "blueberry-lime-background"
 subnav-link-gradient: "blueberry-lime-link"

--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -1,6 +1,6 @@
 ---
 layout: developers
-title:  "Blue Button API Docs"
+title:  "Blue Button 2.0 API Docs"
 date:   2017-10-30 09:21:12 -0500
 description: Instructions for understanding and using the CMS Blue Button 2.0 API to get you up and running quickly.
 landing-page: live
@@ -17,21 +17,21 @@ sections:
   - Sample Beneficiaries
   - Production API Access
   - Developer Guidelines
-  - Blue Button Implementation Guide
+  - Blue Button 2.0 API Implementation Guide
 ctas:
   -
     title: Developer Sandbox
     link: https://sandbox.bluebutton.cms.gov/v1/accounts/mfa/login
   -
-    title: Blue Button Blog
+    title: Blue Button 2.0 API Blog
     link: /blog
 ---
 
 ## Overview
 
-The Centers for Medicare and Medicaid Services (CMS) Blue Button API enables Medicare beneficiaries to connect their Medicare claims data to the applications, services, and research programs they trust.
+The Centers for Medicare and Medicaid Services (CMS) Blue Button 2.0 API enables Medicare beneficiaries to connect their Medicare claims data to the applications, services, and research programs they trust.
 
-The CMS Blue Button API:
+The CMS Blue Button 2.0 API:
 
 - Enables a developer to register a beneficiary-facing application
 - Enables a beneficiary to grant an application access to four years of their Part A, B, and D claims data
@@ -41,9 +41,9 @@ The CMS Blue Button API:
 
 ## Authorization
 
-To use the Blue Button OAuth 2 a developer must [register their application](https://sandbox.bluebutton.cms.gov/v1/o/applications/).
+To use the Blue Button 2.0 OAuth 2 a developer must [register their application](https://sandbox.bluebutton.cms.gov/v1/o/applications/).
 
-A registered application is given a client ID and a client secret. The secret should only be used if it can be kept confidential, such as communication between your server and the Blue Button API. Otherwise the [Client Application Flow](#client-application-flow) may be used.
+A registered application is given a client ID and a client secret. The secret should only be used if it can be kept confidential, such as communication between your server and the Blue Button 2.0 API. Otherwise the [Client Application Flow](#client-application-flow) may be used.
 
 ### Scopes
 
@@ -107,7 +107,7 @@ The [PKCE](https://tools.ietf.org/html/rfc7636) extension provides a technique 
 - plain
 - S256
 
-However, Blue Button 2.0 only supports the “S256” style code challenge.
+However, the Blue Button 2.0 API only supports the “S256” style code challenge.
 
 Where the:  
 ``` python
@@ -122,7 +122,7 @@ More details can be found about this flow on [OAuth.com](https://www.oauth.com/)
 
 ### Registering Your App for Mobile App Support
 
-When you register your application in the Blue Button 2.0 Developer Sandbox, you will want to specify a unique custom URI scheme. This should be a unique value that will not conflict with other custom URI schemes implemented on a user’s mobile device.
+When you register your application in the Blue Button 2.0 API Developer Sandbox, you will want to specify a unique custom URI scheme. This should be a unique value that will not conflict with other custom URI schemes implemented on a user’s mobile device.
 
 We recommend that you define your custom URI scheme using a reverse domain name notation. As we developed our own testing application, we implemented a custom URI scheme of:
 - `gov.cms.bluebutton.oauthtester`
@@ -138,7 +138,7 @@ tld.app.subdomain[.subsubdomain]:/callback/path/endpoint
 
 A coding example of an OAuth 2.0 and PKCE flow is available here: [Authorization Code with PKCE Flow - OAuth 2.0 Playground](https://www.oauth.com/playground/authorization-code-with-pkce.html)
 
-The Blue Button 2.0 engineering team has also created a sample Android application. You can review or fork the code here: [https://github.com/CMSgov/bluebutton-sample-client-android](https://github.com/CMSgov/bluebutton-sample-client-android)
+The Blue Button 2.0 API engineering team has also created a sample Android application. You can review or fork the code here: [https://github.com/CMSgov/bluebutton-sample-client-android](https://github.com/CMSgov/bluebutton-sample-client-android)
 
 ### Redirect_URI
 
@@ -181,7 +181,7 @@ If you are using Mobile OAuth support for communication directly with a mobile d
 Top-level.domain(TLD).domain-name[.sub-domain][.app_name]
 ```
 
-For example, if the Blue Button 2.0 team created an application we might create a custom_url of:
+For example, if the Blue Button 2.0 API team created an application we might create a custom_url of:
 ``` 
 gov.cms.bluebutton.oauthtester
 ```
@@ -197,7 +197,7 @@ To use this flow your application should be registered with `Client Type` set to
 
 #### Request authorization from user
 
-To allow a user to authorize your application, direct them to Blue Button's `authorize` endpoint.
+To allow a user to authorize your application, direct them to the Blue Button 2.0 API `authorize` endpoint.
 The request must include the `response_type` set to `code`, your application's client_id, and your application's redirect_uri. An optional `state` field that your application can use to identify the authorization request is recommended.
 
 ```
@@ -271,7 +271,7 @@ and
 
 To use the client application flow
 direct the user to
-the Blue Button `authorization` endpoint
+the Blue Button 2.0 API `authorization` endpoint
 with the `response_type` parameter set to `token`.
 
 ```
@@ -295,7 +295,7 @@ http://localhost:8080/testclient/callback#access_token=KCHMTX5VHNAXYGYv38eG2RLAX
     &state=8e896a59f0744a8e93bf2f1f13230be5
 ```
 
-Below you will find a sample account you can use to test your Blue Button OAuth implementation. This account mimics a valid MyMedicare.gov account but has reduced functionality. For example, you cannot test “Forgot Password” flow.
+Below you will find a sample account you can use to test your Blue Button 2.0 API OAuth implementation. This account mimics a valid MyMedicare.gov account but has reduced functionality. For example, you cannot test “Forgot Password” flow.
 
 _Jane Doe Username: BBUser29999 Password: PW29999!_
 
@@ -317,7 +317,7 @@ Base Request URL:
 ### UserInfo:
 - Get User Profile from an Authorization Token
 
-As a security measure the date of birth, SSN, and HICN will not be provided by the CMS Blue Button API.
+As a security measure the date of birth, SSN, and HICN will not be provided by the CMS Blue Button 2.0 API.
 
 We use [FHIR Extensions](https://www.hl7.org/fhir/extensibility.html#Extension) in our API responses.
 
@@ -334,7 +334,7 @@ Each one can be thousands of lines long.
 
 That API call will return an Explanation of Benefit that contains many FHIR resources and is typically thousands of lines long.  
 
-[Learn more about the Explanation of Benefits FHIR resource in Blue Button](/eob/)
+[Learn more about the Explanation of Benefits FHIR resource in the Blue Button 2.0 API](/eob/)
 
 <pre>
 {
@@ -767,7 +767,7 @@ We have mapped over 1,300 fields from the CMS claims data warehouse into FHIR.  
 - Part D Events
 - Skilled Nursing Facility Claims
 
-The Blue Button API FHIR data model leverages coding systems specific to Medicare billing forms and/or the Chronic Conditions Warehouse, FHIR and Industry Coding Systems.
+The Blue Button 2.0 API FHIR data model leverages coding systems specific to Medicare billing forms and/or the Chronic Conditions Warehouse, FHIR and Industry Coding Systems.
 
 For Example:
 
@@ -775,7 +775,7 @@ For Example:
 - [HL7 v3 Code System ActCode](http://hl7.org/fhir/v3/ActCode/cs.html)
 - [ICD-10](http://hl7.org/fhir/sid/icd-10)
 
-[View the full list of Blue Button API FHIR Data Model Coding Systems and Identifiers](https://github.com/CMSgov/bluebutton-data-server/blob/master/dev/data-model.md)
+[View the full list of Blue Button 2.0 API FHIR Data Model Coding Systems and Identifiers](https://github.com/CMSgov/bluebutton-data-server/blob/master/dev/data-model.md)
 
 **How Often Will New/Updated Data Be Available?**
 
@@ -783,23 +783,23 @@ Medicare Part A, B, and D claims data will be refreshed weekly.
 
 Our schedules may vary depending on many things like maintenance, delayed delivery of claims to the CCW data warehouse, or additional data quality processing that's needed.
 
-We recommend you have a daily job to fetch new claims data for your users. Please be responsible with your API usage and comply with the Service Management Rights to Limit conditions in the Blue Button API Terms of Service.
+We recommend you have a daily job to fetch new claims data for your users. Please be responsible with your API usage and comply with the Service Management Rights to Limit conditions in the Blue Button 2.0 API Terms of Service.
 
 **Synthetic Data**
 
-The CMS Blue Button API offers a synthetic data set for developers to test against. This means that each request returns a realistic value. For example, if a patient is prescribed the diabetes medication Metformin, the associated cost and date of this prescription will be accurate.
+The CMS Blue Button 2.0 API offers a synthetic data set for developers to test against. This means that each request returns a realistic value. For example, if a patient is prescribed the diabetes medication Metformin, the associated cost and date of this prescription will be accurate.
 
-Please note that this synthetic data set does not represent a longitudinal patient view. The claims—though representative independently—are shuffled and randomly assigned to patients. To build the synthetic data set, we selected a number of random claims, and shuffling them like a deck of cards among a group of fictitious Patient IDs. This will allow developers to test the Blue Button API system, but could result in a patient with records for contradictory procedures.
+Please note that this synthetic data set does not represent a longitudinal patient view. The claims—though representative independently—are shuffled and randomly assigned to patients. To build the synthetic data set, we selected a number of random claims, and shuffling them like a deck of cards among a group of fictitious Patient IDs. This will allow developers to test the Blue Button 2.0 API system, but could result in a patient with records for contradictory procedures.
 
 **Production Data**
 
-The CMS Blue Button API has at least one claim for over 53M beneficiaries.
+The CMS Blue Button 2.0 API has at least one claim for over 53M beneficiaries.
 
-Today, there are approximately 38M beneficiaries in traditional or fee-for-service Medicare.  The Blue Button API has Part A/B/D data for those beneficiaries plus Part D data for some beneficiaries on Medicare Advantage plans.  
+Today, there are approximately 38M beneficiaries in traditional or fee-for-service Medicare.  The Blue Button 2.0 API has Part A/B/D data for those beneficiaries plus Part D data for some beneficiaries on Medicare Advantage plans.  
 
 Part D has always been a separate program, but certain plans include both the MA benefits (Part C) and Part D.  As a result, Part D drug event data is collected separately from MA encounter data.  Part D drug event data for all participants in Part D has been collected by the agency since the program began in the mid-2000s.  
 
-The API also has historical claims data going back four years.  All of these factors contribute to the 53M number we use to describe the total number of beneficiaries available via the Blue Button API.
+The API also has historical claims data going back four years.  All of these factors contribute to the 53M number we use to describe the total number of beneficiaries available via the Blue Button 2.0 API.
 
 ## Try the API
 
@@ -811,9 +811,9 @@ Click "Add an Application" to register a new sample application and get a Client
 
 **Step 2:** Generate a sample token
 
-To test out the Blue Button API, you must first generate a sample token that represents a beneficiary granting consent.
+To test out the Blue Button 2.0 API, you must first generate a sample token that represents a beneficiary granting consent.
 
-To see a sample of Blue Button data you can access the Test Client. 
+To see a sample of Blue Button 2.0 API data you can access the Test Client. 
 
 1.  If you are already logged in to the Developer portal, log out
 2.  In the navigation bar on [https://sandbox.bluebutton.cms.gov](https://sandbox.bluebutton.cms.gov) click on "Test Client"
@@ -952,7 +952,7 @@ you can do the following:
 
 [CSV of 100 sample beneficiaries with rich claims data](/synthetic_users_by_claim_count_full.csv)
 
-When getting started with the Blue Button API, it can be overwhelming to understand all of the coding systems and types of data that can be found in the Explanation of Benefit FHIR resource.
+When getting started with the Blue Button 2.0 API, it can be overwhelming to understand all of the coding systems and types of data that can be found in the Explanation of Benefit FHIR resource.
 
 Below are some hypothetical Beneficiaries that gives you a sense of what is found in claims data.
 
@@ -1037,11 +1037,11 @@ In order to gain production access, an organization should start by reviewing th
 
 ## Developer Guidelines
 
-Below are guidelines you should follow to be successful in your Blue Button API integration.
+Below are guidelines you should follow to be successful in your Blue Button 2.0 API integration.
 
 **Your Privacy Policy**
 
-You will be asked to provide a URL to your privacy policy and terms and conditions when registering your app in the Blue Button Developer Portal.  These links should be easy to access and understand by a beneficiary using your app.  Consider using the [Model Privacy Notice](https://www.healthit.gov/policy-researchers-implementers/model-privacy-notice-mpn).
+You will be asked to provide a URL to your privacy policy and terms and conditions when registering your app in the Blue Button 2.0 API Developer Portal.  These links should be easy to access and understand by a beneficiary using your app.  Consider using the [Model Privacy Notice](https://www.healthit.gov/policy-researchers-implementers/model-privacy-notice-mpn).
 
 **Rate Limiting and Data Refresh**
 
@@ -1049,11 +1049,11 @@ Medicare Part A, B, and D claims data will be refreshed weekly.
 
 Our schedules may vary depending on many things like maintenance, delayed delivery of claims to the CCW data warehouse, or additional data quality processing that's needed.
 
-We recommend you have a daily or weekly job to fetch new claims data for your users.  Please be responsible with your API usage and comply with the Service Management Rights to Limit conditions in the [Blue Button API Terms of Service](/terms/).
+We recommend you have a daily or weekly job to fetch new claims data for your users.  Please be responsible with your API usage and comply with the Service Management Rights to Limit conditions in the [Blue Button 2.0 API Terms of Service](/terms/).
 
-**Use of the Blue Button Logo**
+**Use of the Blue Button 2.0 API Logo**
 
-The Blue Button logo and usage guidelines is detailed [here](https://www.healthit.gov/patients-families/blue-button/blue-button-image).
+The Blue Button 2.0 API logo and usage guidelines is detailed [here](https://www.healthit.gov/patients-families/blue-button/blue-button-image).
 
 **Beneficiary Revokes Access**
 
@@ -1065,21 +1065,21 @@ If you or your users encounters this error message, know that our team is aware 
 
 ---
 
-## Blue Button Implementation Guide
+## Blue Button 2.0 Implementation Guide
 
-The Blue Button team have created a Blue Button 2.0 Implementation Guide (BB2IG).
-You can access the guide here: [Blue Button 2.0 Implementation Guide](/assets/ig/index.html).
+The Blue Button 2.0 API team has created a Blue Button 2.0 API Implementation Guide (BB2IG).
+You can access the guide here: [Blue Button 2.0 API Implementation Guide](/assets/ig/index.html).
 
 The BB2IG features nine profiles in this version of the guide:
 
-<li><a href="/assets/ig/StructureDefinition-bluebutton-patient-claim.html" target="_blank">Blue Button Patient Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-carrier-claim.html" target="_blank">Blue Button Carrier Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-dme-claim.html" target="_blank">Blue Button DME Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-hha-claim.html" target="_blank">Blue Button HHA Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-hospice-claim.html" target="_blank">Blue Button Hospice Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-inpatient-claim.html" target="_blank">Blue Button Inpatient Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-outpatient-claim.html" target="_blank">Blue Button Outpatient Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-pde-claim.html" target="_blank">Blue Button Part D Event Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-snf-claim.html" target="_blank">Blue Button SNF Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-patient-claim.html" target="_blank">Blue Button 2.0 API Patient Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-carrier-claim.html" target="_blank">Blue Button 2.0 API Carrier Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-dme-claim.html" target="_blank">Blue Button 2.0 API DME Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-hha-claim.html" target="_blank">Blue Button 2.0 API HHA Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-hospice-claim.html" target="_blank">Blue Button 2.0 API Hospice Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-inpatient-claim.html" target="_blank">Blue Button 2.0 API Inpatient Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-outpatient-claim.html" target="_blank">Blue Button 2.0 API Outpatient Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-pde-claim.html" target="_blank">Blue Button 2.0 API Part D Event Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-snf-claim.html" target="_blank">Blue Button 2.0 API SNF Claim Profile</a></li>
 
 ---

--- a/_pages/eob.md
+++ b/_pages/eob.md
@@ -25,7 +25,7 @@ ctas:
 
 ## Overview
 
-The [ExplanationOfBenefit FHIR Resource](https://www.hl7.org/fhir/explanationofbenefit.html) is how the Blue Button API represents the bulk of the beneficiary's data.  Each one can be thousands of lines long.
+The [ExplanationOfBenefit FHIR Resource](https://www.hl7.org/fhir/explanationofbenefit.html) is how the Blue Button 2.0 API represents the bulk of the beneficiary's data.  Each one can be thousands of lines long.
 
 <pre>curl --header "Authorization: Bearer AUTHORIZATION TOKEN"  "https://sandbox.bluebutton.cms.gov/v1/fhir/ExplanationOfBenefit/?patient=20140000008325"</pre>
 

--- a/_pages/production-access-user-guide.md
+++ b/_pages/production-access-user-guide.md
@@ -6,16 +6,16 @@ description: "A guide to help you prepare for and understand our requirements fo
 badge: documentation
 permalink: /guide/
 sections:
-- Understanding Blue Button's Mission
+- Understanding the Blue Button 2.0 API Mission
 - Our Requirements for Production Access
 - What does this process look like?
 ---
-<div id="understanding-blue-button-s-mission"></div>
-## Understanding Blue Button's Mission
+<div id="understanding-the-blue-button-2-0-api-mission"></div>
+## Understanding the Blue Button 2.0 API Mission
 
 We're pleased that you're considering applying for production access to the CMS Blue Button 2.0 API. There is a broad and growing community of third-party companies, organizations, and developers building exciting applications that empower Medicare beneficiaries with their personal health information. Our mission is to provide a developer-friendly, standards-based API that enables developers to create these amazing resources for our beneficiaries.
 
-Another core element of our mission is making sure that Medicare beneficiaries (and their data) are protected. Our production access process and terms of service are designed to ensure that the beneficiary feels secure and that they are given the information to make informed decisions when using Blue Button to share their healthcare data with third-party applications. Before you apply for production access, it is vital that you have read and understand the Blue Button terms of service.
+Another core element of our mission is making sure that Medicare beneficiaries (and their data) are protected. Our production access process and terms of service are designed to ensure that the beneficiary feels secure and that they are given the information to make informed decisions when using the Blue Button 2.0 API to share their healthcare data with third-party applications. Before you apply for production access, it is vital that you have read and understand the Blue Button 2.0 API terms of service.
 
 This guide will help make sure you understand the requirements outlined in our terms of service, but you should always treat the terms of service as our official policy.
 

--- a/_posts/2018-04-06-Welcome-to-the-Blue-Button-Blog.md
+++ b/_posts/2018-04-06-Welcome-to-the-Blue-Button-Blog.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Welcome to the Blue Button Blog
+title: Welcome to the Blue Button 2.0 Blog
 date:   2018-03-26 23:22:00 -0600
 categories: general
 badge: blog
@@ -21,7 +21,7 @@ extra_links:
 
 **Welcome!** You have found the Blue Button 2.0 Blog. We hope you find the content useful.
 
-This is a place where The Blue Button Team can post content, such as:
+This is a place where The Blue Button 2.0 Team can post content, such as:
 
 - Code recipes
 - Links to sample applications
@@ -29,7 +29,7 @@ This is a place where The Blue Button Team can post content, such as:
 - Links to presentations and content from other outreach activities.
 
 If you are interested in particular topics please register with our
-<a href="https://groups.google.com/forum/#!forum/Developer-group-for-cms-blue-button-api" target="_blank">Google Group for CMS Blue Button Developers</a>.
+<a href="https://groups.google.com/forum/#!forum/Developer-group-for-cms-blue-button-api" target="_blank">Google Group for CMS Blue Button 2.0 Developers</a>.
 
 The Blue Button 2.0 Google Group is where developers can ask questions, find answers,
 leave feedback and share experiences using the API.

--- a/_posts/2018-05-04-Installing-a-Nodejs-client-application.md
+++ b/_posts/2018-05-04-Installing-a-Nodejs-client-application.md
@@ -115,11 +115,11 @@ Fill out the other fields in the form and click "Save".
 
 Take the Client Id and Client Secret and add them to the respective fields in serverAuth.js file.
 
-If you are connecting to the Sandbox API the **tokenHost** Blue Button API Endpoint is:
+If you are connecting to the Sandbox API the **tokenHost** Blue Button 2.0 API Endpoint is:
 
 - https://sandbox.bluebutton.cms.gov
 
-For the Blue Button production API the Endpoint will be:
+For the Blue Button 2.0 production API the Endpoint will be:
 
 - https://api.bluebutton.cms.gov
 
@@ -137,13 +137,13 @@ Client ID was *ABCDEF12345* you would replace "<enter client id here>" with "ABC
 ```
 // BlueButton Registered Application Credentials
 const credentials = {
-    // Blue Button API sandbox Credentials
+    // Blue Button 2.0 API sandbox Credentials
 	 client: {
 	     id: '<enter client id here>',
 	     secret: '<enter client secret here>',
 	 },
     auth: {
-        tokenHost: '<Blue Button API Endpoint>',
+        tokenHost: '<Blue Button 2.0 API Endpoint>',
         authorizePath: '/v1/o/authorize/',
         tokenPath: '/v1/o/token/'
     }

--- a/_posts/2018-05-19-How-Beneficiaries-Authorize-an-App.md
+++ b/_posts/2018-05-19-How-Beneficiaries-Authorize-an-App.md
@@ -23,7 +23,7 @@ One of the frequent questions we get is: *How does a beneficiary grant access to
 
 Let's look at this step-by-step.
 
-As a developer, let's assume that you have successfully submitted an application to the Blue Button Production API. You have your credentials and have implemented them in your application, or web site.
+As a developer, let's assume that you have successfully submitted an application to the Blue Button 2.0 Production API. You have your credentials and have implemented them in your application, or web site.
 
 *What happens next?*
 

--- a/_posts/2018-06-04-Installing-a-Django-client-application.md
+++ b/_posts/2018-06-04-Installing-a-Django-client-application.md
@@ -60,7 +60,7 @@ Activate the environment with
 
     source ~/.virtualenv/pd_bbc/bin/activate
 
-## Download the Blue Button Client Code
+## Download the Blue Button 2.0 Client Code
 
     mkdir -p ~/developer/pd_bbc
     cd ~/developer/pd_bbc

--- a/_posts/2018-06-05-Speed-up-data-transfers.md
+++ b/_posts/2018-06-05-Speed-up-data-transfers.md
@@ -24,7 +24,7 @@ extra_links:
    link: /blog/index.html
 ---
 
-The Blue Button Team continues to look at performance improvements for the Blue Button 2.0 API. The
+The Blue Button 2.0 Team continues to look at performance improvements for the Blue Button 2.0 API. The
 ExplanationOfBenefit resource can involve a large amount of data being transferred. To improve performance
 in this area we are introducing the ability to apply gzip compression.
 

--- a/_posts/2018-06-07-Bluebutton-FHIR-Implementation-Guide.md
+++ b/_posts/2018-06-07-Bluebutton-FHIR-Implementation-Guide.md
@@ -58,9 +58,9 @@ this link: [Blue Button 2.0 Implementation Guide](/assets/ig/index.html).
 The BB2IG documents structure definitions for the following resources:
 
 <li><a href="/assets/ig/StructureDefinition-bluebutton-patient-claim.html">Blue Button 2.0 Patient Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-carrier-claim.html">Blue Button 2.0 PCarrier Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-dme-claim.html">Blue Button 2.0 PDME Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-hha-claim.html">Blue Button 2.0 PHHA Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-carrier-claim.html">Blue Button 2.0 Carrier Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-dme-claim.html">Blue Button 2.0 DME Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-hha-claim.html">Blue Button 2.0 HHA Claim Profile</a></li>
 <li><a href="/assets/ig/StructureDefinition-bluebutton-hospice-claim.html">Blue Button 2.0 Hospice Claim Profile</a></li>
 <li><a href="/assets/ig/StructureDefinition-bluebutton-inpatient-claim.html">Blue Button 2.0 Inpatient Claim Profile</a></li>
 <li><a href="/assets/ig/StructureDefinition-bluebutton-outpatient-claim.html">Blue Button 2.0 Outpatient Claim Profile</a></li>

--- a/_posts/2018-06-07-Bluebutton-FHIR-Implementation-Guide.md
+++ b/_posts/2018-06-07-Bluebutton-FHIR-Implementation-Guide.md
@@ -61,11 +61,11 @@ The BB2IG documents structure definitions for the following resources:
 <li><a href="/assets/ig/StructureDefinition-bluebutton-carrier-claim.html">Blue Button 2.0 PCarrier Claim Profile</a></li>
 <li><a href="/assets/ig/StructureDefinition-bluebutton-dme-claim.html">Blue Button 2.0 PDME Claim Profile</a></li>
 <li><a href="/assets/ig/StructureDefinition-bluebutton-hha-claim.html">Blue Button 2.0 PHHA Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-hospice-claim.html">Blue Button 2.0 PHospice Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-inpatient-claim.html">Blue Button 2.0 PInpatient Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-outpatient-claim.html">Blue Button 2.0 POutpatient Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-pde-claim.html">Blue Button 2.0 PPart D Event Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-snf-claim.html">Blue Button 2.0 PSNF Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-hospice-claim.html">Blue Button 2.0 Hospice Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-inpatient-claim.html">Blue Button 2.0 Inpatient Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-outpatient-claim.html">Blue Button 2.0 Outpatient Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-pde-claim.html">Blue Button 2.0 Part D Event Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-snf-claim.html">Blue Button 2.0 SNF Claim Profile</a></li>
 
 We welcome feedback on this guide. As always head over to the [Google Developer Group for Blue Button 2.0 API](https://groups.google.com/forum/#!forum/developer-group-for-cms-blue-button-api) and
 leave us your comments.   

--- a/_posts/2018-06-07-Bluebutton-FHIR-Implementation-Guide.md
+++ b/_posts/2018-06-07-Bluebutton-FHIR-Implementation-Guide.md
@@ -24,17 +24,17 @@ extra_links:
    link: /blog/index.html
 ---
 
-The Blue Button team is continually working to improve the Blue Button 2.0 API and the supporting documentation. When
+The Blue Button 2.0 team is continually working to improve the Blue Button 2.0 API and the supporting documentation. When
 the API was announced at HIMSS in March 2018 it created a lot of interest. That interest came not just from developers
 wanting to connect to the API and work with the data it contains, but also from other organizations around the
 healthcare industry, such as insurers and Medicaid agencies. For the latter category of technologists there is significant
-interest in how The Blue Button team built the Fast Healthcare Interoperability Resource (FHIR) records that hold the
+interest in how The Blue Button 2.0 team built the Fast Healthcare Interoperability Resource (FHIR) records that hold the
 beneficiaries' data.
 
 ## FHIR Implementation Guides
 
 FHIR is as much a community as it is a specification. The community shares information about how a solution has been
-built by creating an **Implementation Guide**. The Blue Button Team has created a FHIR Implementation Guide to
+built by creating an **Implementation Guide**. The Blue Button 2.0 Team has created a FHIR Implementation Guide to
 document how we have used FHIR resources in the API.
 
 ## Resources and Profiles
@@ -48,7 +48,7 @@ include extensions (specially coded additional fields and values).
 ## Blue Button 2.0 Implementation Guide
 
 A draft of the Blue Button 2.0 Implementation Guide (BB2IG) is now available as part of the
-[Blue Button Developer Documentation](https://bluebutton.cms.gov) site.
+[Blue Button 2.0 Developer Documentation](https://bluebutton.cms.gov) site.
 
 We are integrating the Implementation Guide into the documentation. If you want to get a preview of the guide check
 this link: [Blue Button 2.0 Implementation Guide](/assets/ig/index.html).
@@ -57,15 +57,15 @@ this link: [Blue Button 2.0 Implementation Guide](/assets/ig/index.html).
 
 The BB2IG documents structure definitions for the following resources:
 
-<li><a href="/assets/ig/StructureDefinition-bluebutton-patient-claim.html">Blue Button Patient Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-carrier-claim.html">Blue Button Carrier Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-dme-claim.html">Blue Button DME Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-hha-claim.html">Blue Button HHA Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-hospice-claim.html">Blue Button Hospice Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-inpatient-claim.html">Blue Button Inpatient Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-outpatient-claim.html">Blue Button Outpatient Claim Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-pde-claim.html">Blue Button Part D Event Profile</a></li>
-<li><a href="/assets/ig/StructureDefinition-bluebutton-snf-claim.html">Blue Button SNF Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-patient-claim.html">Blue Button 2.0 Patient Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-carrier-claim.html">Blue Button 2.0 PCarrier Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-dme-claim.html">Blue Button 2.0 PDME Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-hha-claim.html">Blue Button 2.0 PHHA Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-hospice-claim.html">Blue Button 2.0 PHospice Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-inpatient-claim.html">Blue Button 2.0 PInpatient Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-outpatient-claim.html">Blue Button 2.0 POutpatient Claim Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-pde-claim.html">Blue Button 2.0 PPart D Event Profile</a></li>
+<li><a href="/assets/ig/StructureDefinition-bluebutton-snf-claim.html">Blue Button 2.0 PSNF Claim Profile</a></li>
 
 We welcome feedback on this guide. As always head over to the [Google Developer Group for Blue Button 2.0 API](https://groups.google.com/forum/#!forum/developer-group-for-cms-blue-button-api) and
 leave us your comments.   

--- a/_posts/2018-06-15-Working-With-FHIR.md
+++ b/_posts/2018-06-15-Working-With-FHIR.md
@@ -29,7 +29,7 @@ On June 19th, 2018 the Blue Button 2.0 API is being featured in one of the
 at the HL7 [FHIR DevDays conference](https://www.fhirdevdays.com/boston/) in Boston, MA.
 
 The break-out session and the hands-on practice areas feature exercises to work with different aspects of FHIR.
-For Blue Button 2.0 we are taking developers through interacting with our FHIR API through the OAuth2.0 Interface.
+For Blue Button 2.0 we are taking developers through interacting with our FHIR API through the OAuth 2.0 Interface.
 We felt this was important because many test environments that expose FHIR resources do not protect those resources.
 Yet in the real world OAuth2.0 is typically used to control access. Interacting with an API through an OAuth2.0
 authorization layer can make development more complicated. Therefore, this exercise sets out to simplify that

--- a/_posts/2018-06-15-Working-With-FHIR.md
+++ b/_posts/2018-06-15-Working-With-FHIR.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Blue Button at HL7 FHIR DevDays
+title: Blue Button 2.0 at HL7 FHIR DevDays
 date:  2018-06-17 5:30 PM -0600
 categories: code
 permalink: /blog/:title
@@ -29,7 +29,7 @@ On June 19th, 2018 the Blue Button 2.0 API is being featured in one of the
 at the HL7 [FHIR DevDays conference](https://www.fhirdevdays.com/boston/) in Boston, MA.
 
 The break-out session and the hands-on practice areas feature exercises to work with different aspects of FHIR.
-For Blue Button we are taking developers through interacting with our FHIR API through the OAuth2.0 Interface.
+For Blue Button 2.0 we are taking developers through interacting with our FHIR API through the OAuth2.0 Interface.
 We felt this was important because many test environments that expose FHIR resources do not protect those resources.
 Yet in the real world OAuth2.0 is typically used to control access. Interacting with an API through an OAuth2.0
 authorization layer can make development more complicated. Therefore, this exercise sets out to simplify that
@@ -46,10 +46,10 @@ What follows below is the Hands-on exercise that was provided for FHIR DevDays. 
 
 ## Hands-on Exercise
 
-During the hands-on session of the Blue Button on FHIR tutorial, you will learn how to connect an application to the CMS Blue Button Sandbox environment. Authorize access as one of 30,000 synthetic beneficiaries and retrieve a Patient record or a bundle of Coverage or ExplanationOfBenefit resources.
+During the hands-on session of the Blue Button 2.0 on FHIR tutorial, you will learn how to connect an application to the CMS Blue Button 2.0 Sandbox environment. Authorize access as one of 30,000 synthetic beneficiaries and retrieve a Patient record or a bundle of Coverage or ExplanationOfBenefit resources.
 
 After completing this tutorial, you will be able to:
--	Access the CMS Blue Button CapabilityStatement
+-	Access the CMS Blue Button 2.0 CapabilityStatement
 -	Connect to an Oauth2.0 protected API
 -	Authorize access as a target patient/beneficiary
 -	Retrieve Stu3 FHIR resources for the authorizing beneficiary
@@ -175,7 +175,7 @@ Sample data:
       }
     }
 
--	Copy and paste the curl commands into a terminal window to view Blue Button FHIR Resources.
+-	Copy and paste the curl commands into a terminal window to view Blue Button 2.0 FHIR Resources.
 
 ## Requirements
 - Internet connection

--- a/_posts/2018-07-24-Delving-in-to-Blue-Button-Data.md
+++ b/_posts/2018-07-24-Delving-in-to-Blue-Button-Data.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Delving in to Blue Button Data
+title: Delving in to Blue Button 2.0 Data
 date:  2018-07-24 2:30 PM -0600
 categories: code
 permalink: /blog/:title

--- a/_posts/2018-10-09-BBDC18-Roadmap-Q-and-A.md
+++ b/_posts/2018-10-09-BBDC18-Roadmap-Q-and-A.md
@@ -40,7 +40,7 @@ app in production. Stay tuned, this will be announced in a future blog post.
 ## Q: Will we add Medicaid data to the Blue Button 2.0 API?
 **A:**  At this time we have no plans to add Medicaid data to the Blue Button 2.0 API.
 
-## Q: Blue Button currently only includes the National Drug Code for a drug. Will descriptions be added to explain these codes?
+## Q: Blue Button 2.0 currently only includes the National Drug Code for a drug. Will descriptions be added to explain these codes?
 **A: Yes**.  We are in the process of adding drug code descriptions to the
 Blue Button 2.0 API. These descriptions will be located in each FHIR Coding
 element’s “display” field and will include the drug’s proprietary name
@@ -49,12 +49,12 @@ and its substance name.
 ## Q: Will descriptions for other coding systems be added to the Blue Button 2.0 API?
 **A: Yes**.  Once we complete work on adding the National Drug Code we
 plan to move on to add brief human-readable descriptions for some of the
-other coding systems used in the Blue Button API’s claims data.
+other coding systems used in the Blue Button 2.0 API’s claims data.
 This includes: ICD diagnosis and procedure codes, HCPCS Level I
 and Level II codes, and perhaps others.
 
-## Q: How can provenance of data transferred by the Blue Button API be assured?
-**A:**  The Blue Button Team is committed to building a Developer-friendly, standards-based API.
+## Q: How can provenance of data transferred by the Blue Button 2.0 API be assured?
+**A:**  The Blue Button 2.0 Team is committed to building a Developer-friendly, standards-based API.
 As such we would like to see a common industry-solution to data provenance.  
 There are some examples that could be followed. The Veterans Administration in
 conjunction with the US Post Office did some work to apply a checksum to data received.

--- a/_posts/2018-12-18-Install-a-ruby-on-rails-client-app.md
+++ b/_posts/2018-12-18-Install-a-ruby-on-rails-client-app.md
@@ -35,7 +35,7 @@ However, the installation does have a series of prerequisites: Docker, Docker-co
 For this post, we assume you are installing the application on a MacBook Pro running a current version of MacOS. Therefore, we will be using a unix-style shell for terminal access.
 
 The steps we will go through are:
-1. Get your Blue Button Developer Sandbox credentials
+1. Get your Blue Button 2.0 Developer Sandbox credentials
 2. Prepare your environment
 3. Get the Ruby on Rails code from GitHub
 4. Configure the application credentials

--- a/_posts/2019-02-07-introducing-native-mobile-app-support.md
+++ b/_posts/2019-02-07-introducing-native-mobile-app-support.md
@@ -55,7 +55,7 @@ For mobile app developers this allows integration with the Blue Button 2.0 API t
 
 ## How to Get Started with Native Mobile App Support
 
-Find documentation on Native Mobile App Support in the [Blue Button documentation](https://bluebutton.cms.gov/developers/#nativeMobileApp).
+Find documentation on Native Mobile App Support in the [Blue Button 2.0 documentation](https://bluebutton.cms.gov/developers/#nativeMobileApp).
 
 A coding example of an OAuth 2.0 and PKCE flow is available here: [Authorization Code with PKCE Flow - OAuth 2.0 Playground](https://www.oauth.com/playground/authorization-code-with-pkce.html)
 

--- a/_posts/2019-11-13-giving-beneficiaries-more-granular-choice-of-data-sharing copy.md
+++ b/_posts/2019-11-13-giving-beneficiaries-more-granular-choice-of-data-sharing copy.md
@@ -12,7 +12,7 @@ extra_links:
    link: /blog/index.html
 ---
 
-As adoption of the Blue Button 2.0 API (BB2.0 API) grows, the CMS Blue Button team continues to look at ways to improve the API and stay current with evolving standards. A primary goal for CMS with the BB2.0 API is to help beneficiaries make informed choices about the applications they use and the data they share. To enhance the security and privacy posture for Medicare beneficiaries using the BB2.0 API, we are pleased to announce two changes to the API:
+As adoption of the Blue Button 2.0 API (BB2.0 API) grows, the CMS Blue Button 2.0 team continues to look at ways to improve the API and stay current with evolving standards. A primary goal for CMS with the BB2.0 API is to help beneficiaries make informed choices about the applications they use and the data they share. To enhance the security and privacy posture for Medicare beneficiaries using the BB2.0 API, we are pleased to announce two changes to the API:
 
 1.	A feature enhancement to enable beneficiaries to choose whether they want to share their demographic information with a given application. This change is described in more detail below. 
 2.	[Updates to the BB2.0 API Terms of Service, described in more detail here](/blog/ensuring-beneficiary-privacy-and-security-through-new-application-onboarding-requirements.html).

--- a/_posts/2019-11-14-ensuring-beneficiary-privacy-and-security-through-new-application-onboarding-requirements.md
+++ b/_posts/2019-11-14-ensuring-beneficiary-privacy-and-security-through-new-application-onboarding-requirements.md
@@ -12,7 +12,7 @@ extra_links:
    link: /blog/index.html
 ---
 
-As adoption of the Blue Button 2.0 API (BB2.0 API) grows, the CMS Blue Button team continues to look at ways to improve the API and stay current with evolving standards. A primary goal for CMS with the BB2.0 API is to help beneficiaries make more informed choices about the applications they use and the data they share. To enhance the security and privacy posture for Medicare beneficiaries using the BB2.0 API, we are pleased to announce the following changes to our service:
+As adoption of the Blue Button 2.0 API (BB2.0 API) grows, the CMS Blue Button 2.0 team continues to look at ways to improve the API and stay current with evolving standards. A primary goal for CMS with the BB2.0 API is to help beneficiaries make more informed choices about the applications they use and the data they share. To enhance the security and privacy posture for Medicare beneficiaries using the BB2.0 API, we are pleased to announce the following changes to our service:
 
 1.	New requirements for third-party applications seeking access to Medicare claims data through the BB2.0 API, described below. 
 2.	A feature enhancement to enable beneficiaries to choose whether they want to share their demographic information with a given application ([more information on this enhancement available here](/blog/giving-beneficiaries-more-granular-choice-of-data-sharing-copy.html)).
@@ -33,13 +33,13 @@ The new requirements consist of the following documents:
 
 ## What does this mean for existing production applications?
 
-Organizations with applications that are currently in production will continue to have access to Blue Button under the existing terms of service until March 31st, 2020. However, before March 31st, 2020, an organization currently in production must review the new terms of service, user guide, and checklist, and seek re-approval from the CMS team to demonstrate adherence to the new requirements in order to maintain access to the API. Once an organization believes it is fulfilling all items detailed in the user guide and checklist and adheres to the new terms of service, they should email [bluebuttonapi@cms.hhs.gov](mailto:bluebuttonapi@cms.hhs.gov) to set up a meeting with the CMS team to review. 
+Organizations with applications that are currently in production will continue to have access to Blue Button 2.0 under the existing terms of service until March 31st, 2020. However, before March 31st, 2020, an organization currently in production must review the new terms of service, user guide, and checklist, and seek re-approval from the CMS team to demonstrate adherence to the new requirements in order to maintain access to the API. Once an organization believes it is fulfilling all items detailed in the user guide and checklist and adheres to the new terms of service, they should email [bluebuttonapi@cms.hhs.gov](mailto:bluebuttonapi@cms.hhs.gov) to set up a meeting with the CMS team to review. 
 
 **Every application currently in production will require re-review to ensure compliance with the new requirements by March 31st, 2020**. Many apps may already comply with, or even exceed, our new requirements - and we’re committed to working together to make the re review process as easy as possible. You can use our guides, mentioned above, to prepare and you can also reach out to us with any questions or concerns by contacting the BB2.0 email, above.
 
 Once your app is ready for a re-review meeting submit your request for an “application review meeting” via email to [bluebuttonapi@cms.hhs.gov](mailto:bluebuttonapi@cms.hhs.gov).
 
-## What does this mean for applications looking to request production access to Blue Button for the first time?
+## What does this mean for applications looking to request production access to Blue Button 2.0 for the first time?
 
 **Effective 11/14/2019 (today), organizations seeking production access to the API must adhere to the requirements detailed in the user guide, checklist, and updated terms of service**. In order to gain production access, an organization should start by reviewing the [updated terms of service](/terms/), [user guide](/guide/), and [checklist](/checklist/). Once an organization believes it is fulfilling all the requirements detailed in the checklist and is adherent to the new terms of service, they should email bluebuttonapi@cms.hhs.gov to set up a production access demonstration meeting with the CMS team. 
 

--- a/_posts/2020-02-11-check-out-updates-to-the-developer-documentation.md
+++ b/_posts/2020-02-11-check-out-updates-to-the-developer-documentation.md
@@ -12,7 +12,7 @@ extra_links:
    link: /blog/index.html
 ---
 
-Recently there has been an increase in questions on the [Blue Button Google Group](https://groups.google.com/forum/#!forum/Developer-group-for-cms-blue-button-api) about a ‘500 error’ when using the [Test Client](https://sandbox.bluebutton.cms.gov/testclient/).
+Recently there has been an increase in questions on the [Blue Button 2.0 Google Group](https://groups.google.com/forum/#!forum/Developer-group-for-cms-blue-button-api) about a ‘500 error’ when using the [Test Client](https://sandbox.bluebutton.cms.gov/testclient/).
 
 A few changes have been made to help you avoid this issue when starting to use the Blue Button 2.0 API.
 

--- a/blog/category/code.html
+++ b/blog/category/code.html
@@ -1,6 +1,6 @@
 ---
 layout: post_with_category2
-title: Blue Button 2.0 Blog
+title: Blue Button 2.0 API Blog
 category: code
 categories: code
 badge: blog

--- a/blog/category/general.html
+++ b/blog/category/general.html
@@ -1,6 +1,6 @@
 ---
 layout: post_with_category2
-title: Blue Button 2.0 Blog
+title: Blue Button 2.0 API Blog
 category: general
 categories: general
 badge: Blog

--- a/blog/category/latest.html
+++ b/blog/category/latest.html
@@ -1,6 +1,6 @@
 ---
 layout: post_with_category2
-title: Blue Button 2.0 Blog
+title: Blue Button 2.0 API Blog
 category: latest
 categories: latest
 badge: blog

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default-full
-title: Blue Button 2.0 Blog
+title: Blue Button 2.0 API Blog
 description: Get the latest news, updates, and more from the Blue Button 2.0 API.
 badge: blog
 ---

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: home
-title:  "CMS Blue Button 2.0 API"
+title:  "CMS Blue Button 2.0"
 date:   2017-10-30 09:21:12 -0500
 description: A developer-friendly, standards-based API that enables Medicare beneficiaries to connect their claims data to the applications, services and research programs they trust.
 landing-page: live

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: home
-title:  "Blue Button 2.0"
+title:  "CMS Blue Button 2.0 API"
 date:   2017-10-30 09:21:12 -0500
 description: A developer-friendly, standards-based API that enables Medicare beneficiaries to connect their claims data to the applications, services and research programs they trust.
 landing-page: live
@@ -40,17 +40,17 @@ ctas:
  
 ## Overview
 
-Blue Button 2.0 from CMS is an API that contains four years of Medicare Part A, B and D data for 53 million Medicare beneficiaries.
+The Blue Button 2.0 API from CMS is an API that contains four years of Medicare Part A, B and D data for 53 million Medicare beneficiaries.
 
 This data reveals a variety of information about a beneficiary’s health, including type of Medicare coverage, drug prescriptions, primary care treatment and cost. Beneficiaries also have full control over how their data can be used and by whom, with identity and authorization controlled by MyMedicare.gov.
 
-Blue Button 2.0 uses the [HL7 FHIR standard](https://www.hl7.org/fhir/) for beneficiary data and the [OAuth 2.0 standard](https://oauth.net/2/) for beneficiary authorization.
+The Blue Button 2.0 API uses the [HL7 FHIR standard](https://www.hl7.org/fhir/) for beneficiary data and the [OAuth 2.0 standard](https://oauth.net/2/) for beneficiary authorization.
 
 ---
 
 ## Getting started
 
-You can get started on building your integration with the Blue Button API by following these steps:
+You can get started on building your integration with the Blue Button 2.0 API by following these steps:
 
 - [Read the Developer Docs](/developers)
 - [Join the Developer Sandbox](https://sandbox.bluebutton.cms.gov/v1/accounts/create)
@@ -62,7 +62,7 @@ You can get started on building your integration with the Blue Button API by fol
 
 ## Value and Use Cases
 
-Developers integrate with the Blue Button API adding value for beneficiaries, providers, care organizations, researchers and many more across Healthcare and Life Sciences to:
+Developers integrate with the Blue Button 2.0 API adding value for beneficiaries, providers, care organizations, researchers and many more across Healthcare and Life Sciences to:
 
 **_Reduce patient burden_**
 
@@ -84,4 +84,4 @@ A health application can aggregate data into a health dashboard for beneficiarie
 
 ## Support
 
-The Blue Button 2.0 Google Group is where developers can ask questions, find answers, leave feedback and share experiences using the API. [Visit the Blue Button Google Group.](https://groups.google.com/forum/#!forum/developer-group-for-cms-blue-button-api)
+The Blue Button 2.0 API Google Group is where developers can ask questions, find answers, leave feedback and share experiences using the API. [Visit the Blue Button 2.0 API Google Group.](https://groups.google.com/forum/#!forum/developer-group-for-cms-blue-button-api)

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,4 +1,4 @@
-# Blue Button API Static Site
+# Blue Button 2.0 API Static Site
 
 ## Creating a release
 


### PR DESCRIPTION
**Context:**
Because there is an original "Blue Button" service where users can download a flat file of their claims data, we want to be sure all the copy on our static site to distinguishes the Blue Button 2.0 API from the original Blue Button service.

This PR has multiple commits of a lot of changes. I `"grepped"` several different ways to find all references. We essentially wanted to take any reference to `Blue Button` and ensure it said either `Blue Button 2.0` or `Blue Button 2.0 API`.