### PR TITLE
BB2-4521 - exclude static assets uploaded on rsync

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -134,6 +134,7 @@ jobs:
         run: |
           echo "::echo::off"
           rsync -av --delete \
+            --exclude=/bbapi-static/ \
             -e "ssh" \
             ./dist/ \
             ${{ secrets.AKAMAI_SSH_USER }}@bluebuttoncms.rsync.upload.akamai.com:${{ steps.akamai-path.outputs.path }} > /tmp/rsync.log 2>&1


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-4521](https://jira.cms.gov/browse/BB2-4521)


### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
-->

Excludes the folder path used by web-server for uploading static assets to NetStorage

