### PR TITLE
BB2-5080: Add a section on navigating a v3 EOB search bundle to stati…

### DIFF
--- a/src/content/api-documentation/consuming-the-data.mdx
+++ b/src/content/api-documentation/consuming-the-data.mdx
@@ -111,6 +111,37 @@ Bundle navigation example:
 }
 ```
 
+In v3, you will navigate through a bundle in a similar manner, with some differences:
+
+- No "first" attribute will ever be within the URLs provided by `Bundle.link`
+- Rather than seeing startIndex within the different URLs, you will see `_offset`
+
+v3 Bundle navigation example:
+
+
+```json
+{
+  "resourceType": "Bundle",
+  "id": "b97d4bf9-bb41-492c-b853-5933a7cb8bf7",
+  // ...
+  "total": 10,
+  "link": [
+    {
+      "relation": "next",
+      "url": "{host}/v3/fhir/ExplanationOfBenefit/?_count=10&_offset=15&patient=..."
+    },
+    {
+      "relation": "previous",
+      "url": "{host}/v3/fhir/ExplanationOfBenefit/?_count=10&&patient=..."
+    },
+    {
+      "relation": "self",
+      "url": "{host}/v3/fhir/ExplanationOfBenefit/?_count=10&_offset=5&patient=..."
+    }
+  ],
+}
+```
+
 ## Working with identifiers
 
 In FHIR, the difference between the `Resource.id` (resource ID) and `identifier` attributes within a resource can be confusing. 


### PR DESCRIPTION
…c site

**JIRA Ticket:**
[BB2-5080](https://jira.cms.gov/browse/BB2-5080)


### What Does This PR Do?
Adds a section to the 'Consuming the Data' page within our static site about navigating a v3 EOB Search bundle, as there are slight differences compared to navigating a v1 or v2 EOB Search bundle.

Leaving in draft until the Design team has a chance to weigh in on the verbiage.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

### Validation
- Run the project, go to http://localhost:4321/api-documentation/consuming-the-data, confirm you see the following below the Bundle navigation example:

<img width="543" height="629" alt="Screenshot 2026-08-18 at 12 55 05 PM" src="https://github.com/user-attachments/assets/c7109448-98c3-4b8b-a054-ab7b7c7b23ff" />

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team security engineer's approval.
