### PR TITLE
Adjust fhir astro file to render StructureDefinition as html

### DIFF
--- a/src/pages/fhir/[...slug].astro
+++ b/src/pages/fhir/[...slug].astro
@@ -25,7 +25,7 @@ export const getStaticPaths = Route.createGetStaticPaths(async () => {
 
 const { post } = Astro.props
 
-// Differential only lists elements this profile adds/overrides relative to its base
+// Helpers to simplify the rendering of StructureDefinition elements in a table. These are only used if the resourceType is StructureDefinition.
 const elements = post.data.resourceType === 'StructureDefinition' ? (post.data.differential?.element ?? []) : [];
 
 function cardinality(el: any) {
@@ -81,17 +81,21 @@ function depth(path: string) {
 )}
 
 {post.data.resourceType === 'StructureDefinition' && (
-  <BaseLayout title={`Structure Definition: ${post.data.title}`} description={post.data.description || ''}>
+  <BaseLayout title={`Structure Definition: ${post.data.title || post.data.name}`} description={post.data.description || ''}>
     <DocsLayout showSideNav={false} showToc={true}>
       <div class="usa-prose">
         <h2>Structure Definition: {post.data.name}</h2>
         <p>{post.data.title}</p>
-        <p>Base Definition: {post.data.baseDefinition}</p>
+        <p>Base Definition: <a href={post.data.baseDefinition}>{post.data.baseDefinition}</a></p>
         <p>Status: {post.data.status}</p>
         <p>Kind: {post.data.kind}</p>
         <p>Type: {post.data.type}</p>
-        <h2>Description:</h2>
-        <p>{post.data.description}</p>
+        {post.data.description && (
+          <>
+            <h2>Description:</h2>
+            <p>{post.data.description}</p>
+          </>
+        )}
         <h2>Elements (Differential)</h2>
         <table>
           <thead>

--- a/src/pages/fhir/[...slug].astro
+++ b/src/pages/fhir/[...slug].astro
@@ -17,109 +17,116 @@ export type Props = {
 export const getStaticPaths = Route.createGetStaticPaths(async () => {
   const posts = await getCollection('fhir')
   return posts.map((post) => ({
-      // This preserves the correct casing for these files. Forcing them to lowercase, alhough preferred, could cause 404 errors on Cloudfront/Akamai
-      params: { slug: `/${post.data.resourceType}/${post.data.id}` },
-      props: { post },
-    }))
+    // This preserves the correct casing for these files. Forcing them to lowercase, alhough preferred, could cause 404 errors on Cloudfront/Akamai
+    params: { slug: `/${post.data.resourceType}/${post.data.id}` },
+    props: { post },
+  }))
 })
 
 const { post } = Astro.props
 
 // Helpers to simplify the rendering of StructureDefinition elements in a table. These are only used if the resourceType is StructureDefinition.
-const elements = post.data.resourceType === 'StructureDefinition' ? (post.data.differential?.element ?? []) : [];
+const elements = post.data.resourceType === 'StructureDefinition' ? (post.data.differential?.element ?? []) : []
 
 function cardinality(el: any) {
-  return `${el.min ?? 0}..${el.max ?? '*'}`;
+  return `${el.min ?? 0}..${el.max ?? '*'}`
 }
 
 function isZeroedOut(el: any) {
-  return el.max === '0';
+  return el.max === '0'
 }
 
 function typeNames(el: any) {
-  if (!el.type) return '';
-  return el.type.map((t: any) => t.code).join(' | ');
+  if (!el.type) return ''
+  return el.type.map((t: any) => t.code).join(' | ')
 }
 
 // Elements are named like "Patient.name.given" — indent based on depth
 function depth(path: string) {
-  return path.split('.').length - 1;
+  return path.split('.').length - 1
 }
 ---
 
-{post.data.resourceType === 'CodeSystem' && (
-  <BaseLayout title={`Variable: ${post.data.title}`} description={post.data.description || ''}>
-    <DocsLayout showSideNav={false} showToc={true}>
-      <div class="usa-prose">
-        <h2>Variable: {post.data.name}</h2>
-        <p>{post.data.title}</p>
-        <h2>Description:</h2>
-        <p>{post.data.description}</p>
-        <h2>Values</h2>
-        <p>This variable is coded, and will contain one of the following values.</p>
-        <table>
-          <thead>
-            <tr>
-              <th>Value</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            {
-              post.data.concept.map((item) => (
+{
+  post.data.resourceType === 'CodeSystem' && (
+    <BaseLayout title={`Variable: ${post.data.title}`} description={post.data.description || ''}>
+      <DocsLayout showSideNav={false} showToc={true}>
+        <div class="usa-prose">
+          <h2>Variable: {post.data.name}</h2>
+          <p>{post.data.title}</p>
+          <h2>Description:</h2>
+          <p>{post.data.description}</p>
+          <h2>Values</h2>
+          <p>This variable is coded, and will contain one of the following values.</p>
+          <table>
+            <thead>
+              <tr>
+                <th>Value</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {post.data.concept.map((item) => (
                 <tr>
                   <td>{item.code}</td>
                   <td>{item.display}</td>
                 </tr>
-              ))
-            }
-          </tbody>
-        </table>
-      </div>
-    </DocsLayout>
-  </BaseLayout>
-)}
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </DocsLayout>
+    </BaseLayout>
+  )
+}
 
-{post.data.resourceType === 'StructureDefinition' && (
-  <BaseLayout title={`Structure Definition: ${post.data.title || post.data.name}`} description={post.data.description || ''}>
-    <DocsLayout showSideNav={false} showToc={true}>
-      <div class="usa-prose">
-        <h2>Structure Definition: {post.data.name}</h2>
-        <p>{post.data.title}</p>
-        <p>Base Definition: <a href={post.data.baseDefinition}>{post.data.baseDefinition}</a></p>
-        <p>Status: {post.data.status}</p>
-        <p>Kind: {post.data.kind}</p>
-        <p>Type: {post.data.type}</p>
-        {post.data.description && (
-          <>
-            <h2>Description:</h2>
-            <p>{post.data.description}</p>
-          </>
-        )}
-        <h2>Elements (Differential)</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>Path</th>
-              <th>Cardinality</th>
-              <th>Type</th>
-              <th>Short</th>
-            </tr>
-          </thead>
-          <tbody>
-            {elements.map((el: any) => (
-              <tr style={isZeroedOut(el) ? { textDecoration: 'line-through', opacity: 0.6 } : {}}>
-                <td style={{ paddingLeft: `${depth(el.path) * 1.25}rem` }}>
-                  <code>{el.path}</code>
-                </td>
-                <td>{cardinality(el)}</td>
-                <td>{typeNames(el)}</td>
-                <td>{el.short ?? ''}</td>
+{
+  post.data.resourceType === 'StructureDefinition' && (
+    <BaseLayout
+      title={`Structure Definition: ${post.data.title || post.data.name}`}
+      description={post.data.description || ''}
+    >
+      <DocsLayout showSideNav={false} showToc={true}>
+        <div class="usa-prose">
+          <h2>Structure Definition: {post.data.name}</h2>
+          <p>{post.data.title}</p>
+          <p>
+            Base Definition: <a href={post.data.baseDefinition}>{post.data.baseDefinition}</a>
+          </p>
+          <p>Status: {post.data.status}</p>
+          <p>Kind: {post.data.kind}</p>
+          <p>Type: {post.data.type}</p>
+          {post.data.description && (
+            <>
+              <h2>Description:</h2>
+              <p>{post.data.description}</p>
+            </>
+          )}
+          <h2>Elements (Differential)</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Path</th>
+                <th>Cardinality</th>
+                <th>Type</th>
+                <th>Short</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </DocsLayout>
-  </BaseLayout>
-)}
+            </thead>
+            <tbody>
+              {elements.map((el: any) => (
+                <tr style={isZeroedOut(el) ? { textDecoration: 'line-through', opacity: 0.6 } : {}}>
+                  <td style={{ paddingLeft: `${depth(el.path) * 1.25}rem` }}>
+                    <code>{el.path}</code>
+                  </td>
+                  <td>{cardinality(el)}</td>
+                  <td>{typeNames(el)}</td>
+                  <td>{el.short ?? ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </DocsLayout>
+    </BaseLayout>
+  )
+}

--- a/src/pages/fhir/[...slug].astro
+++ b/src/pages/fhir/[...slug].astro
@@ -5,21 +5,18 @@ import BaseLayout from '#layouts/base-layout.astro'
 import DocsLayout from '#layouts/docs-layout.astro'
 import { getCollection } from 'astro:content'
 
-type CodeSystemPost = CollectionEntry<'fhir'> & { data: { resourceType: 'CodeSystem' } }
+type FhirPost = CollectionEntry<'fhir'>
 
 export const Route = createRoute({
   routeId: '/fhir/[...slug]',
 })
 
 export type Props = {
-  post: CodeSystemPost
+  post: FhirPost
 }
-
-export const getStaticPaths = Route.createGetStaticPaths<Props>(async () => {
+export const getStaticPaths = Route.createGetStaticPaths(async () => {
   const posts = await getCollection('fhir')
-  return posts
-    .filter((post): post is CodeSystemPost => post.data.resourceType === 'CodeSystem')
-    .map((post) => ({
+  return posts.map((post) => ({
       // This preserves the correct casing for these files. Forcing them to lowercase, alhough preferred, could cause 404 errors on Cloudfront/Akamai
       params: { slug: `/${post.data.resourceType}/${post.data.id}` },
       props: { post },
@@ -27,35 +24,98 @@ export const getStaticPaths = Route.createGetStaticPaths<Props>(async () => {
 })
 
 const { post } = Astro.props
+
+// Differential only lists elements this profile adds/overrides relative to its base
+const elements = post.data.resourceType === 'StructureDefinition' ? (post.data.differential?.element ?? []) : [];
+
+function cardinality(el: any) {
+  return `${el.min ?? 0}..${el.max ?? '*'}`;
+}
+
+function isZeroedOut(el: any) {
+  return el.max === '0';
+}
+
+function typeNames(el: any) {
+  if (!el.type) return '';
+  return el.type.map((t: any) => t.code).join(' | ');
+}
+
+// Elements are named like "Patient.name.given" — indent based on depth
+function depth(path: string) {
+  return path.split('.').length - 1;
+}
 ---
 
-<BaseLayout title={`Variable: ${post.data.title}`} description={post.data.description || ''}>
-  <DocsLayout showSideNav={false} showToc={true}>
-    <div class="usa-prose">
-      <h2>Variable: {post.data.name}</h2>
-      <p>{post.data.title}</p>
-      <h2>Description:</h2>
-      <p>{post.data.description}</p>
-      <h2>Values</h2>
-      <p>This variable is coded, and will contain one of the following values.</p>
-      <table>
-        <thead
-          ><tr>
-            <td>Value</td>
-            <td>Description</td>
-          </tr></thead
-        >
-        <tbody>
-          {
-            post.data.concept.map((item) => (
-              <tr>
-                <td>{item.code}</td>
-                <td>{item.display}</td>
+{post.data.resourceType === 'CodeSystem' && (
+  <BaseLayout title={`Variable: ${post.data.title}`} description={post.data.description || ''}>
+    <DocsLayout showSideNav={false} showToc={true}>
+      <div class="usa-prose">
+        <h2>Variable: {post.data.name}</h2>
+        <p>{post.data.title}</p>
+        <h2>Description:</h2>
+        <p>{post.data.description}</p>
+        <h2>Values</h2>
+        <p>This variable is coded, and will contain one of the following values.</p>
+        <table>
+          <thead>
+            <tr>
+              <th>Value</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              post.data.concept.map((item) => (
+                <tr>
+                  <td>{item.code}</td>
+                  <td>{item.display}</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    </DocsLayout>
+  </BaseLayout>
+)}
+
+{post.data.resourceType === 'StructureDefinition' && (
+  <BaseLayout title={`Structure Definition: ${post.data.title}`} description={post.data.description || ''}>
+    <DocsLayout showSideNav={false} showToc={true}>
+      <div class="usa-prose">
+        <h2>Structure Definition: {post.data.name}</h2>
+        <p>{post.data.title}</p>
+        <p>Base Definition: {post.data.baseDefinition}</p>
+        <p>Status: {post.data.status}</p>
+        <p>Kind: {post.data.kind}</p>
+        <p>Type: {post.data.type}</p>
+        <h2>Description:</h2>
+        <p>{post.data.description}</p>
+        <h2>Elements (Differential)</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Path</th>
+              <th>Cardinality</th>
+              <th>Type</th>
+              <th>Short</th>
+            </tr>
+          </thead>
+          <tbody>
+            {elements.map((el: any) => (
+              <tr style={isZeroedOut(el) ? { textDecoration: 'line-through', opacity: 0.6 } : {}}>
+                <td style={{ paddingLeft: `${depth(el.path) * 1.25}rem` }}>
+                  <code>{el.path}</code>
+                </td>
+                <td>{cardinality(el)}</td>
+                <td>{typeNames(el)}</td>
+                <td>{el.short ?? ''}</td>
               </tr>
-            ))
-          }
-        </tbody>
-      </table>
-    </div>
-  </DocsLayout>
-</BaseLayout>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </DocsLayout>
+  </BaseLayout>
+)}

--- a/src/pages/fhir/[...slug].astro
+++ b/src/pages/fhir/[...slug].astro
@@ -7,6 +7,11 @@ import { getCollection } from 'astro:content'
 
 type FhirPost = CollectionEntry<'fhir'>
 
+type StructureDefinitionElement = Extract<
+  CollectionEntry<'fhir'>['data'],
+  { resourceType: 'StructureDefinition' }
+>['differential']['element'][number]
+
 export const Route = createRoute({
   routeId: '/fhir/[...slug]',
 })
@@ -28,17 +33,17 @@ const { post } = Astro.props
 // Helpers to simplify the rendering of StructureDefinition elements in a table. These are only used if the resourceType is StructureDefinition.
 const elements = post.data.resourceType === 'StructureDefinition' ? (post.data.differential?.element ?? []) : []
 
-function cardinality(el: any) {
-  return `${el.min ?? 0}..${el.max ?? '*'}`
+function cardinality({ min, max }: StructureDefinitionElement) {
+  return `${min ?? 0}..${max ?? '*'}`
 }
 
-function isZeroedOut(el: any) {
-  return el.max === '0'
+function isZeroedOut({ max }: StructureDefinitionElement) {
+  return max === '0'
 }
 
-function typeNames(el: any) {
-  if (!el.type) return ''
-  return el.type.map((t: any) => t.code).join(' | ')
+function typeNames({ type }: StructureDefinitionElement) {
+  if (!type) return ''
+  return type.map((t) => t.code).join(' | ')
 }
 
 // Elements are named like "Patient.name.given" — indent based on depth
@@ -113,7 +118,7 @@ function depth(path: string) {
               </tr>
             </thead>
             <tbody>
-              {elements.map((el: any) => (
+              {elements.map((el) => (
                 <tr style={isZeroedOut(el) ? { textDecoration: 'line-through', opacity: 0.6 } : {}}>
                   <td style={{ paddingLeft: `${depth(el.path) * 1.25}rem` }}>
                     <code>{el.path}</code>

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -39,7 +39,8 @@ export const structureDefinitionSchema = z.object({
       path: z.string(),
       short: z.string().optional(),
       definition: z.string().optional(),
-      max: z.string().optional(),
+      min: z.coerce.string().optional(),
+      max: z.coerce.string().optional(),
       fixedUri: z.url().optional(),
       type: z.array(z.object({
         code: z.string(),


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-5143](https://jira.cms.gov/browse/BB2-5143)


### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
-->
This PR defines a format for rendering StructureDefinition files as html on the static site. In combination with Akamai adjustments that are now active, this allows for StructureDefinition pages to be rendered as html or as json depending on the Accept header provided on the request.

### What Should Reviewers Watch For?
<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
How does the new format look? Anything missing that is important to have here?

### Validation

<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->
The full list of pages is here. It's a lot, so I wouldn't necessarily expect every one to be thoroughly reviewed, but at least spot checking these should be enough. In your browser, it should by default present the html versions, but you can also specify an Accept header of application/json to see the json format. Spot check a few of each format to ensure correct behavior.

- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-BUYIN-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-CMBND-DEEMD-COPMT-LVL-ID
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-CMBND-DEEMD-IND
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-CMBND-DEEMD-PRM-PCT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-CNTRCT-NUM
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-CVRG-TYPE-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-DSBLD-STUS-ID
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-DUAL-STUS-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-DUAL-TYPE-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-ENRLMT-EMPLR-SBSDY-SW
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-ENRLMT-RSN-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-ESRD-STUS-ID
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/Bene-MBI
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-MDCR-ENTLMT-RSN-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-MDCR-ENTLMT-STUS-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-MDCR-STUS-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BENE-PBP-NUM
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/Beneficiary
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/BFDAuditLog
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-ADJSTMT-TYPE-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-CARR-PMT-DNL-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-CLNCL-TRIL-NUM
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-CMS-PROC-DT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-CNTRCTR-NUM
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-DISP-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-FED-TYPE-SRVC-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-FI-ACTN-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-HIPPS-UNCOMPD-CARE-AMT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-IDR-LD-DT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-LINE-ANSTHSA-UNIT-CNT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-LINE-CARR-HPSA-SCRCTY-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-LINE-PRFNL-MTUS-CNT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-LINE-RX-NUM
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-MDCR-IP-PPS-DRG-WT-NUM
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-MDCR-NPMT-RSN-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-MDCR-PRFNL-PRVDR-ASGNMT-SW
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-MTUS-IND-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-NRLN-RIC-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-OP-SRVC-TYPE-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-OPRTNL-DSPRTNT-AMT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-OPRTNL-IME-AMT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-OTAF-ONE-IND-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-PHYSN-ASTNT-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-PMT-80-100-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-PRCNG-LCLTY-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-PRCSG-IND-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-PRMRY-PYR-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-PRVDR-PRTCPTG-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-PRVDR-SPCLTY-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-PRVDR-TAX-NUM
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-QUERY-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-REV-CNTR-STUS-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-REV-DSCNT-IND-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-REV-PACKG-IND-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-REV-PMT-MTHD-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-RNDRG-PRVDR-PRTCPTG-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-SBMT-FRMT-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-SBMTR-CNTRCT-NUM
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-SBMTR-CNTRCT-PBP-NUM
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-SRVC-DDCTBL-SW
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CLM-SUPLR-TYPE-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/CNTRCT-PBP-SGMT-NUM
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/Coverage-Base
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/DGNS-DRG-OUTLIER-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/DiagnosisComponent
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/ExplanationOfBenefit-Base
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/ExplanationOfBenefit-Institutional-Base
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/ExplanationOfBenefit-Pharmacy
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/ExplanationOfBenefit-PriorAuth
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/ExplanationOfBenefit-Professional-Base
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/LineItemComponent
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/MEDICAID-STATE-CD
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/MR-COUNT-END-DT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/MR-COUNT-IND
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/MR-COUNT-ST-DT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/Operation-C4DIC
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/PA-DECISION-DT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/PA-DECISION-EXP-DT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/PA-DECISION
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/PA-DT-ADDED
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/PA-DT-UPDATED
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/PA-REQ-REC-DT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/PA-REQ-SUB-DT
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/ProcedureComponent
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/Provider
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/RRB-EXCL-IND
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/SERVICE-CNTS
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/stats
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/stats
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/SupportingInfoComponent
- https://test.static.bluebutton.cms.gov/fhir/StructureDefinition/SVC-RENDER-ST

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team security engineer's approval.
